### PR TITLE
Eliminate catch throwable

### DIFF
--- a/src/main/java/io/vlingo/wire/fdx/bidirectional/rsocket/RSocketClientChannel.java
+++ b/src/main/java/io/vlingo/wire/fdx/bidirectional/rsocket/RSocketClientChannel.java
@@ -59,7 +59,7 @@ public class RSocketClientChannel implements ClientRequestResponseChannel {
     if (this.channelSocket != null && !this.channelSocket.isDisposed()) {
       try {
         this.channelSocket.dispose();
-      } catch (final Throwable t) {
+      } catch (final Exception t) {
         logger.error("Unexpected error on closing channel socket", t);
       }
     }
@@ -135,7 +135,7 @@ public class RSocketClientChannel implements ClientRequestResponseChannel {
                             .subscribe(ignored -> {}, throwable -> logger.error("Unexpected error on closing channel socket", throwable));
         }
       }
-    } catch (final Throwable t) {
+    } catch (final Exception t) {
       logger.warn("Failed to create RSocket client channel for {}, because {}", this.address, t.getMessage());
       close();
     }
@@ -159,7 +159,7 @@ public class RSocketClientChannel implements ClientRequestResponseChannel {
         final ByteBuffer payloadData = payload.getData();
         final ConsumerByteBuffer put = pooledBuffer.put(payloadData);
         consumer.consume(put.flip());
-      } catch (final Throwable e) {
+      } catch (final Exception e) {
         logger.error("Unexpected error reading incoming payload", e);
         pooledBuffer.release();
       } finally {

--- a/src/main/java/io/vlingo/wire/fdx/inbound/rsocket/RSocketChannelInboundReader.java
+++ b/src/main/java/io/vlingo/wire/fdx/inbound/rsocket/RSocketChannelInboundReader.java
@@ -6,12 +6,7 @@
 // one at https://mozilla.org/MPL/2.0/.
 package io.vlingo.wire.fdx.inbound.rsocket;
 
-import io.rsocket.AbstractRSocket;
-import io.rsocket.ConnectionSetupPayload;
-import io.rsocket.Payload;
-import io.rsocket.RSocket;
-import io.rsocket.RSocketFactory;
-import io.rsocket.SocketAcceptor;
+import io.rsocket.*;
 import io.rsocket.frame.decoder.PayloadDecoder;
 import io.rsocket.transport.netty.server.CloseableChannel;
 import io.rsocket.transport.netty.server.TcpServerTransport;
@@ -60,7 +55,7 @@ public class RSocketChannelInboundReader implements ChannelReader, ChannelMessag
     if (this.serverSocket != null && !this.serverSocket.isDisposed()) {
       try {
         this.serverSocket.dispose();
-      } catch (final Throwable t) {
+      } catch (final Exception t) {
         logger.error("Unexpected error on closing inbound channel {}", this.name, t);
       }
     }
@@ -117,7 +112,7 @@ public class RSocketChannelInboundReader implements ChannelReader, ChannelMessag
             rawMessageBuilder.workBuffer().put(payloadData);
             
             dispatcher.dispatchMessagesFor(rawMessageBuilder);
-          } catch (final Throwable t) {
+          } catch (final Exception t) {
             logger.error("Unexpected error in inbound channel {}. Message ignored.", name, t);
             //Clear builder resources in case of error. Otherwise we will get a BufferOverflow.
             rawMessageBuilder.prepareForNextMessage();

--- a/src/main/java/io/vlingo/wire/fdx/outbound/rsocket/RSocketOutboundChannel.java
+++ b/src/main/java/io/vlingo/wire/fdx/outbound/rsocket/RSocketOutboundChannel.java
@@ -43,7 +43,7 @@ public class RSocketOutboundChannel implements ManagedOutboundChannel {
     if (this.clientSocket != null && !this.clientSocket.isDisposed()) {
       try {
         this.clientSocket.dispose();
-      } catch (final Throwable t) {
+      } catch (final Exception t) {
         logger.error("Unexpected error on closing outbound channel", t);
       }
     }
@@ -100,7 +100,7 @@ public class RSocketOutboundChannel implements ManagedOutboundChannel {
         this.clientSocket.onClose()
                          .doFinally(signalType -> logger.info("RSocket outbound channel for {} is closed", this.address))
                          .subscribe(ignored -> {}, throwable -> logger.error("Unexpected error on closing outbound channel", throwable));
-      } catch (final Throwable t) {
+      } catch (final Exception t) {
         logger.warn("Failed to create RSocket outbound channel for {}, because {}", this.address, t.getMessage());
         close();
         return Optional.empty();

--- a/src/test/java/io/vlingo/wire/fdx/bidirectional/rsocket/RSocketClientChannelTest.java
+++ b/src/test/java/io/vlingo/wire/fdx/bidirectional/rsocket/RSocketClientChannelTest.java
@@ -6,21 +6,6 @@
 // one at https://mozilla.org/MPL/2.0/.
 package io.vlingo.wire.fdx.bidirectional.rsocket;
 
-import java.nio.ByteBuffer;
-import java.time.Duration;
-import java.util.LinkedHashSet;
-import java.util.List;
-import java.util.Set;
-import java.util.UUID;
-import java.util.concurrent.CopyOnWriteArrayList;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicInteger;
-
-import org.junit.Assert;
-import org.junit.Test;
-import org.reactivestreams.Publisher;
-
 import io.rsocket.AbstractRSocket;
 import io.rsocket.Payload;
 import io.rsocket.RSocket;
@@ -35,8 +20,22 @@ import io.vlingo.wire.channel.ResponseChannelConsumer;
 import io.vlingo.wire.node.Address;
 import io.vlingo.wire.node.AddressType;
 import io.vlingo.wire.node.Host;
+import org.junit.Assert;
+import org.junit.Test;
+import org.reactivestreams.Publisher;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
+
+import java.nio.ByteBuffer;
+import java.time.Duration;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 
 public class RSocketClientChannelTest {
   private static final AtomicInteger TEST_PORT = new AtomicInteger(49240);
@@ -269,7 +268,7 @@ public class RSocketClientChannelTest {
     if (server != null) {
       try {
         server.dispose();
-      } catch (final Throwable t) {
+      } catch (final Exception t) {
         //ignore
       }
     }

--- a/src/test/java/io/vlingo/wire/fdx/inbound/rsocket/RSocketChannelInboundReaderTest.java
+++ b/src/test/java/io/vlingo/wire/fdx/inbound/rsocket/RSocketChannelInboundReaderTest.java
@@ -13,11 +13,7 @@ import io.vlingo.wire.fdx.outbound.ManagedOutboundChannel;
 import io.vlingo.wire.fdx.outbound.rsocket.RSocketOutboundChannel;
 import io.vlingo.wire.message.ByteBufferAllocator;
 import io.vlingo.wire.message.RawMessage;
-import io.vlingo.wire.node.Address;
-import io.vlingo.wire.node.Host;
-import io.vlingo.wire.node.Id;
-import io.vlingo.wire.node.Name;
-import io.vlingo.wire.node.Node;
+import io.vlingo.wire.node.*;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -47,7 +43,7 @@ public class RSocketChannelInboundReaderTest {
 
       try {
         channelReader.openFor(consumer);
-      } catch (Throwable e) {
+      } catch (Exception e) {
         Assert.fail(e.getMessage());
       }
 
@@ -77,7 +73,7 @@ public class RSocketChannelInboundReaderTest {
 
       try {
         channelReader.openFor(consumer);
-      } catch (Throwable e) {
+      } catch (Exception e) {
         Assert.fail(e.getMessage());
       }
 
@@ -109,7 +105,7 @@ public class RSocketChannelInboundReaderTest {
 
       try {
         channelReader.openFor(consumer);
-      } catch (Throwable e) {
+      } catch (Exception e) {
         Assert.fail(e.getMessage());
       }
 


### PR DESCRIPTION
Replaces `catch(Throwable)` with `catch(Exception)` so that the application will not ignore `Error`.