### PR TITLE
fixes abstract initializer null reference

### DIFF
--- a/src/main/java/io/vlingo/wire/fdx/outbound/AbstractManagedOutboundChannelProvider.java
+++ b/src/main/java/io/vlingo/wire/fdx/outbound/AbstractManagedOutboundChannelProvider.java
@@ -6,10 +6,7 @@
 // one at https://mozilla.org/MPL/2.0/.
 package io.vlingo.wire.fdx.outbound;
 
-import io.vlingo.wire.node.AddressType;
-import io.vlingo.wire.node.Configuration;
-import io.vlingo.wire.node.Id;
-import io.vlingo.wire.node.Node;
+import io.vlingo.wire.node.*;
 
 import java.util.Collection;
 import java.util.HashMap;
@@ -17,6 +14,11 @@ import java.util.Map;
 import java.util.TreeMap;
 
 public abstract class AbstractManagedOutboundChannelProvider implements ManagedOutboundChannelProvider {
+
+  protected static Address addressOf(final Node node, final AddressType type) {
+    return (type == AddressType.OP ? node.operationalAddress() : node.applicationAddress());
+  }
+
   private final Configuration configuration;
   private final Node node;
   private final Map<Id, ManagedOutboundChannel> nodeChannels = new HashMap<>();

--- a/src/main/java/io/vlingo/wire/fdx/outbound/rsocket/ManagedOutboundRSocketChannelProvider.java
+++ b/src/main/java/io/vlingo/wire/fdx/outbound/rsocket/ManagedOutboundRSocketChannelProvider.java
@@ -17,24 +17,19 @@ import io.vlingo.wire.node.Configuration;
 import io.vlingo.wire.node.Node;
 
 public class ManagedOutboundRSocketChannelProvider extends AbstractManagedOutboundChannelProvider {
-  private final ClientTransport rsocketClientTransport;
-  private final Address address;
+
+  private static ClientTransport transportFor(final Address address) {
+    return TcpClientTransport.create(address.hostName(), address.port());
+  }
 
   public ManagedOutboundRSocketChannelProvider(final Node node, final AddressType type, final Configuration configuration) {
     super(node, type, configuration);
-    this.address = (type == AddressType.OP ? node.operationalAddress() : node.applicationAddress());
-    this.rsocketClientTransport = TcpClientTransport.create(address.hostName(), address.port());
-  }
-
-  public ManagedOutboundRSocketChannelProvider(final Node node, final AddressType type, final ClientTransport clientTransport,
-                                               final Configuration configuration) {
-    super(node, type, configuration);
-    this.address = (type == AddressType.OP ? node.operationalAddress() : node.applicationAddress());
-    this.rsocketClientTransport = clientTransport;
   }
 
   @Override
   protected ManagedOutboundChannel unopenedChannelFor(final Node node, final Configuration configuration, final AddressType type) {
-    return new RSocketOutboundChannel(address, this.rsocketClientTransport, configuration.logger());
+    final Address address = addressOf(node, type);
+    return new RSocketOutboundChannel(address, transportFor(address), configuration.logger());
   }
+
 }

--- a/src/main/java/io/vlingo/wire/fdx/outbound/tcp/ManagedOutboundSocketChannelProvider.java
+++ b/src/main/java/io/vlingo/wire/fdx/outbound/tcp/ManagedOutboundSocketChannelProvider.java
@@ -9,7 +9,6 @@ package io.vlingo.wire.fdx.outbound.tcp;
 
 import io.vlingo.wire.fdx.outbound.AbstractManagedOutboundChannelProvider;
 import io.vlingo.wire.fdx.outbound.ManagedOutboundChannel;
-import io.vlingo.wire.node.Address;
 import io.vlingo.wire.node.AddressType;
 import io.vlingo.wire.node.Configuration;
 import io.vlingo.wire.node.Node;
@@ -21,8 +20,6 @@ public class ManagedOutboundSocketChannelProvider extends AbstractManagedOutboun
 
   @Override
   protected ManagedOutboundChannel unopenedChannelFor(final Node node, final Configuration configuration, final AddressType type) {
-    final Address address = (type == AddressType.OP ? node.operationalAddress() : node.applicationAddress());
-
-    return new ManagedOutboundSocketChannel(node, address, configuration.logger());
+    return new ManagedOutboundSocketChannel(node, addressOf(node, type), configuration.logger());
   }
 }


### PR DESCRIPTION
Replaces field access of null references (`address`, `rsocketClientTransport`) in `ManagedOutboundRSocketChannelProvider#unopenedChannelFor` with static method equivalents.