### PR TITLE
ServerRequestResponseChannel implementation based on Netty

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -85,6 +85,11 @@
       <version>1.2.9</version>
     </dependency>
     <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-all</artifactId>
+      <version>4.1.48.Final</version>
+    </dependency>
+    <dependency>
       <groupId>io.rsocket</groupId>
       <artifactId>rsocket-core</artifactId>
       <version>${io.rsocket.version}</version>
@@ -94,7 +99,7 @@
       <artifactId>rsocket-transport-netty</artifactId>
       <version>${io.rsocket.version}</version>
     </dependency>
-    <dependency>      
+    <dependency>
       <groupId>io.projectreactor.addons</groupId>
       <artifactId>reactor-extra</artifactId>
       <version>${io.projectreactor.addons.version}</version>

--- a/src/main/java/io/vlingo/wire/fdx/bidirectional/ServerRequestResponseChannel.java
+++ b/src/main/java/io/vlingo/wire/fdx/bidirectional/ServerRequestResponseChannel.java
@@ -7,8 +7,6 @@
 
 package io.vlingo.wire.fdx.bidirectional;
 
-import io.rsocket.Closeable;
-import io.rsocket.transport.ServerTransport;
 import io.vlingo.actors.ActorInstantiator;
 import io.vlingo.actors.Address;
 import io.vlingo.actors.Definition;
@@ -16,7 +14,6 @@ import io.vlingo.actors.Stage;
 import io.vlingo.actors.Stoppable;
 import io.vlingo.common.Completes;
 import io.vlingo.wire.channel.RequestChannelConsumerProvider;
-import io.vlingo.wire.fdx.bidirectional.rsocket.RSocketServerChannelActor;
 
 public interface ServerRequestResponseChannel extends Stoppable {
   static ServerRequestResponseChannel start(
@@ -112,42 +109,6 @@ public interface ServerRequestResponseChannel extends Stoppable {
     }
   }
 
-  static class RSocketServerRequestResponseChannelInstantiator implements ActorInstantiator<RSocketServerChannelActor> {
-    private static final long serialVersionUID = -1999865617618138682L;
-
-    private final RequestChannelConsumerProvider provider;
-    private final ServerTransport<? extends Closeable> serverTransport;
-    private final int port;
-    private final String name;
-    private final int maxBufferPoolSize;
-    private final int messageBufferSize;
-
-    public RSocketServerRequestResponseChannelInstantiator(
-            final RequestChannelConsumerProvider provider,
-            final ServerTransport<? extends Closeable> serverTransport,
-            final int port,
-            final String name,
-            final int maxBufferPoolSize,
-            final int messageBufferSize) {
-
-      this.provider = provider;
-      this.serverTransport = serverTransport;
-      this.port = port;
-      this.name = name;
-      this.maxBufferPoolSize = maxBufferPoolSize;
-      this.messageBufferSize = messageBufferSize;
-    }
-
-    @Override
-    public RSocketServerChannelActor instantiate() {
-      return new RSocketServerChannelActor(provider, serverTransport, port, name, maxBufferPoolSize, messageBufferSize);
-    }
-
-    @Override
-    public Class<RSocketServerChannelActor> type() {
-      return RSocketServerChannelActor.class;
-    }
-  }
 
   Completes<Integer> port();
 }

--- a/src/main/java/io/vlingo/wire/fdx/bidirectional/ServerRequestResponseChannel.java
+++ b/src/main/java/io/vlingo/wire/fdx/bidirectional/ServerRequestResponseChannel.java
@@ -14,6 +14,7 @@ import io.vlingo.actors.Stage;
 import io.vlingo.actors.Stoppable;
 import io.vlingo.common.Completes;
 import io.vlingo.wire.channel.RequestChannelConsumerProvider;
+import io.vlingo.wire.fdx.bidirectional.netty.server.NettyServerChannelActor;
 
 public interface ServerRequestResponseChannel extends Stoppable {
   static ServerRequestResponseChannel start(
@@ -62,6 +63,27 @@ public interface ServerRequestResponseChannel extends Stoppable {
               stage.world().defaultLogger());
 
     return channel;
+  }
+
+  static ServerRequestResponseChannel startWithNetty(
+          final Stage stage,
+          final Address address,
+          final String mailboxName,
+          final RequestChannelConsumerProvider provider,
+          final int port,
+          final String name,
+          final int processorPoolSize,
+          final int maxBufferPoolSize,
+          final int maxMessageSize) {
+
+    final ActorInstantiator<NettyServerChannelActor> instantiator =
+            new NettyServerChannelActor.Instantiator(provider, port, name, processorPoolSize, maxBufferPoolSize, maxMessageSize);
+
+    return stage.actorFor(
+              ServerRequestResponseChannel.class,
+              Definition.has(instantiator.type(), instantiator, mailboxName, address.name()),
+              address,
+              stage.world().defaultLogger());
   }
 
   void close();

--- a/src/main/java/io/vlingo/wire/fdx/bidirectional/netty/server/NettyClientHandler.java
+++ b/src/main/java/io/vlingo/wire/fdx/bidirectional/netty/server/NettyClientHandler.java
@@ -1,0 +1,94 @@
+// Copyright © 2012-2020 VLINGO LABS. All rights reserved.
+//
+// This Source Code Form is subject to the terms of the
+// Mozilla Public License, v. 2.0. If a copy of the MPL
+// was not distributed with this file, You can obtain
+// one at https://mozilla.org/MPL/2.0/.
+package io.vlingo.wire.fdx.bidirectional.netty.server;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.EmptyByteBuf;
+import io.netty.buffer.Unpooled;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandlerAdapter;
+import io.netty.util.ReferenceCountUtil;
+import io.vlingo.common.pool.ElasticResourcePool;
+import io.vlingo.wire.channel.RequestChannelConsumer;
+import io.vlingo.wire.channel.RequestChannelConsumerProvider;
+import io.vlingo.wire.channel.RequestResponseContext;
+import io.vlingo.wire.channel.ResponseSenderChannel;
+import io.vlingo.wire.message.ConsumerByteBuffer;
+import io.vlingo.wire.message.ConsumerByteBufferPool;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+final class NettyClientHandler extends ChannelInboundHandlerAdapter implements ResponseSenderChannel {
+  private final static Logger logger = LoggerFactory.getLogger(NettyClientHandler.class);
+  private final RequestChannelConsumer consumer;
+  private final ConsumerByteBufferPool readBufferPool;
+
+  NettyClientHandler(final RequestChannelConsumerProvider consumerProvider, final int maxBufferPoolSize, final int maxMessageSize) {
+    this.consumer = consumerProvider.requestChannelConsumer();
+    this.readBufferPool = new ConsumerByteBufferPool(ElasticResourcePool.Config.of(maxBufferPoolSize), maxMessageSize);
+  }
+
+  @Override
+  public void channelRead(final ChannelHandlerContext ctx, final Object msg) {
+    if (msg == null || msg == Unpooled.EMPTY_BUFFER || msg instanceof EmptyByteBuf) {
+      return;
+    }
+    if (logger.isTraceEnabled()) {
+      logger.debug("Request received");
+    }
+    try {
+      final NettyServerChannelContext channelContext = new NettyServerChannelContext(ctx, this);
+
+      final ConsumerByteBuffer pooledBuffer = readBufferPool.acquire("NettyClientHandler#channelRead");
+      try {
+        final ByteBuf byteBuf = (ByteBuf) msg;
+        byte[] bytes = new byte[byteBuf.readableBytes()];
+        byteBuf.readBytes(bytes);
+
+        pooledBuffer.put(bytes);
+
+        this.consumer.consume(channelContext, pooledBuffer.flip());
+      } catch (Throwable t) {
+        pooledBuffer.release();
+        throw t;
+      }
+    } catch (Throwable throwable) {
+      logger.error("Error reading the incoming data.", throwable);
+      ctx.close();
+    } finally {
+      ReferenceCountUtil.release(msg);
+    }
+  }
+
+  @Override
+  public void exceptionCaught(final ChannelHandlerContext ctx, final Throwable cause) throws Exception {
+    super.exceptionCaught(ctx, cause);
+    logger.error("Unexpected exception", cause);
+  }
+
+  @Override
+  public void abandon(final RequestResponseContext<?> context) {
+    final ChannelHandlerContext nettyChannelContext = ((NettyServerChannelContext) context).getNettyChannelContext();
+    nettyChannelContext.close();
+  }
+
+  @Override
+  public void respondWith(final RequestResponseContext<?> context, final ConsumerByteBuffer buffer) {
+    final ChannelHandlerContext nettyChannelContext = ((NettyServerChannelContext) context).getNettyChannelContext();
+
+    final ByteBuf reply = nettyChannelContext.alloc()
+                                             .buffer(buffer.limit());
+    reply.writeBytes(buffer.asByteBuffer());
+
+    nettyChannelContext.writeAndFlush(reply)
+                       .addListener(future -> {
+                         if (logger.isTraceEnabled()) {
+                           logger.debug("Reply sent");
+                         }
+                       });
+  }
+}

--- a/src/main/java/io/vlingo/wire/fdx/bidirectional/netty/server/NettyServerChannelActor.java
+++ b/src/main/java/io/vlingo/wire/fdx/bidirectional/netty/server/NettyServerChannelActor.java
@@ -50,7 +50,7 @@ public class NettyServerChannelActor extends Actor implements ServerRequestRespo
                               @Override
                               public void initChannel(SocketChannel ch) throws Exception {
                                 ch.pipeline()
-                                  .addLast(new NettyClientHandler(provider, maxBufferPoolSize, maxMessageSize));
+                                  .addLast(new NettyInboundHandler(provider, maxBufferPoolSize, maxMessageSize));
                               }
                             })
                             .bind(port)

--- a/src/main/java/io/vlingo/wire/fdx/bidirectional/netty/server/NettyServerChannelActor.java
+++ b/src/main/java/io/vlingo/wire/fdx/bidirectional/netty/server/NettyServerChannelActor.java
@@ -21,6 +21,9 @@ import io.vlingo.wire.fdx.bidirectional.ServerRequestResponseChannel;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * Implementation of {@link ServerRequestResponseChannel} based on Netty (https://netty.io/wiki/user-guide-for-4.x.html)
+ */
 public class NettyServerChannelActor extends Actor implements ServerRequestResponseChannel {
   private final static Logger logger = LoggerFactory.getLogger(NettyServerChannelActor.class);
 

--- a/src/main/java/io/vlingo/wire/fdx/bidirectional/netty/server/NettyServerChannelActor.java
+++ b/src/main/java/io/vlingo/wire/fdx/bidirectional/netty/server/NettyServerChannelActor.java
@@ -1,0 +1,119 @@
+// Copyright © 2012-2020 VLINGO LABS. All rights reserved.
+//
+// This Source Code Form is subject to the terms of the
+// Mozilla Public License, v. 2.0. If a copy of the MPL
+// was not distributed with this file, You can obtain
+// one at https://mozilla.org/MPL/2.0/.
+package io.vlingo.wire.fdx.bidirectional.netty.server;
+
+import io.netty.bootstrap.ServerBootstrap;
+import io.netty.channel.ChannelFuture;
+import io.netty.channel.ChannelInitializer;
+import io.netty.channel.EventLoopGroup;
+import io.netty.channel.nio.NioEventLoopGroup;
+import io.netty.channel.socket.SocketChannel;
+import io.netty.channel.socket.nio.NioServerSocketChannel;
+import io.vlingo.actors.Actor;
+import io.vlingo.actors.ActorInstantiator;
+import io.vlingo.common.Completes;
+import io.vlingo.wire.channel.RequestChannelConsumerProvider;
+import io.vlingo.wire.fdx.bidirectional.ServerRequestResponseChannel;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class NettyServerChannelActor extends Actor implements ServerRequestResponseChannel {
+  private final static Logger logger = LoggerFactory.getLogger(NettyServerChannelActor.class);
+
+  private final int port;
+  private final String name;
+  private final EventLoopGroup bossGroup;
+  private final EventLoopGroup workerGroup;
+  private final ChannelFuture channelFuture;
+
+  public NettyServerChannelActor(final RequestChannelConsumerProvider provider, final int port, final String name, final int processorPoolSize,
+                                 final int maxBufferPoolSize, final int maxMessageSize) {
+    this.port = port;
+    this.name = name;
+
+    this.bossGroup = new NioEventLoopGroup();
+    this.workerGroup = new NioEventLoopGroup(processorPoolSize);
+
+    try {
+      final ServerBootstrap b = new ServerBootstrap();
+
+      this.channelFuture = b.group(bossGroup, workerGroup)
+                            .channel(NioServerSocketChannel.class)
+                            .childHandler(new ChannelInitializer<SocketChannel>() {
+                              @Override
+                              public void initChannel(SocketChannel ch) throws Exception {
+                                ch.pipeline()
+                                  .addLast(new NettyClientHandler(provider, maxBufferPoolSize, maxMessageSize));
+                              }
+                            })
+                            .bind(port)
+                            .sync();
+      logger.info("Netty server {} actor started", this.name);
+    } catch (InterruptedException e) {
+      logger.error("Netty server {} actor failed to initialize", this.name, e);
+      throw new RuntimeException(e);
+    }
+  }
+
+  @Override
+  public void close() {
+    try {
+      this.channelFuture.channel()
+                        .close()
+                        .await()
+                        .sync();
+
+      this.bossGroup.shutdownGracefully()
+                    .await()
+                    .sync();
+
+      this.workerGroup.shutdownGracefully()
+                      .await()
+                      .sync();
+
+      logger.info("Netty server actor {} closed", this.name);
+    } catch (Throwable throwable) {
+      logger.error("Netty server actor {} was not closed properly", this.name, throwable);
+    }
+  }
+
+  @Override
+  public Completes<Integer> port() {
+    return Completes.withSuccess(this.port);
+  }
+
+  public static class Instantiator implements ActorInstantiator<NettyServerChannelActor> {
+    private static final long serialVersionUID = -5114262266054911219L;
+
+    private final RequestChannelConsumerProvider provider;
+    private final int port;
+    private final String name;
+    private final int processorPoolSize;
+    private final int maxBufferPoolSize;
+    private final int maxMessageSize;
+
+    public Instantiator(final RequestChannelConsumerProvider provider, final int port, final String name, final int processorPoolSize,
+                        final int maxBufferPoolSize, final int maxMessageSize) {
+      this.provider = provider;
+      this.port = port;
+      this.name = name;
+      this.processorPoolSize = processorPoolSize;
+      this.maxBufferPoolSize = maxBufferPoolSize;
+      this.maxMessageSize = maxMessageSize;
+    }
+
+    @Override
+    public NettyServerChannelActor instantiate() {
+      return new NettyServerChannelActor(this.provider, this.port, this.name, this.processorPoolSize, this.maxBufferPoolSize, this.maxMessageSize);
+    }
+
+    @Override
+    public Class<NettyServerChannelActor> type() {
+      return NettyServerChannelActor.class;
+    }
+  }
+}

--- a/src/main/java/io/vlingo/wire/fdx/bidirectional/netty/server/NettyServerChannelContext.java
+++ b/src/main/java/io/vlingo/wire/fdx/bidirectional/netty/server/NettyServerChannelContext.java
@@ -1,0 +1,61 @@
+// Copyright © 2012-2020 VLINGO LABS. All rights reserved.
+//
+// This Source Code Form is subject to the terms of the
+// Mozilla Public License, v. 2.0. If a copy of the MPL
+// was not distributed with this file, You can obtain
+// one at https://mozilla.org/MPL/2.0/.
+package io.vlingo.wire.fdx.bidirectional.netty.server;
+
+import io.netty.channel.ChannelHandlerContext;
+import io.vlingo.wire.channel.RequestResponseContext;
+import io.vlingo.wire.channel.ResponseSenderChannel;
+import io.vlingo.wire.message.ConsumerByteBuffer;
+
+final class NettyServerChannelContext implements RequestResponseContext<ConsumerByteBuffer> {
+
+  private final ChannelHandlerContext nettyChannelContext;
+  private Object closingData;
+  private Object consumerData;
+  private ResponseSenderChannel sender;
+
+  NettyServerChannelContext(final ChannelHandlerContext nettyChannelContext, final ResponseSenderChannel sender) {
+    this.nettyChannelContext = nettyChannelContext;
+    this.sender = sender;
+  }
+
+  @Override
+  @SuppressWarnings("unchecked")
+  public <T> T consumerData() {
+    return (T) consumerData;
+  }
+
+  @Override
+  public <T> T consumerData(final T workingData) {
+    this.consumerData = workingData;
+    return workingData;
+  }
+
+  @Override
+  public boolean hasConsumerData() {
+    return consumerData != null;
+  }
+
+  @Override
+  public String id() {
+    return null;
+  }
+
+  @Override
+  public ResponseSenderChannel sender() {
+    return this.sender;
+  }
+
+  @Override
+  public void whenClosing(final Object data) {
+    this.closingData = data;
+  }
+  
+  ChannelHandlerContext getNettyChannelContext() {
+    return nettyChannelContext;
+  }
+}

--- a/src/main/java/io/vlingo/wire/fdx/bidirectional/rsocket/RSocketServerChannelActor.java
+++ b/src/main/java/io/vlingo/wire/fdx/bidirectional/rsocket/RSocketServerChannelActor.java
@@ -17,6 +17,7 @@ import io.rsocket.SocketAcceptor;
 import io.rsocket.frame.decoder.PayloadDecoder;
 import io.rsocket.transport.ServerTransport;
 import io.vlingo.actors.Actor;
+import io.vlingo.actors.ActorInstantiator;
 import io.vlingo.actors.Logger;
 import io.vlingo.actors.Stoppable;
 import io.vlingo.common.Completes;
@@ -31,11 +32,9 @@ public class RSocketServerChannelActor extends Actor implements ServerRequestRes
   private final String name;
   private final Closeable serverSocket;
   private final Integer port;
-  
-  public RSocketServerChannelActor(final RequestChannelConsumerProvider provider,
-                                   final ServerTransport<? extends Closeable> serverTransport,
-                                   final int port, final String name, final int maxBufferPoolSize,
-                                   final int messageBufferSize) {
+
+  public RSocketServerChannelActor(final RequestChannelConsumerProvider provider, final ServerTransport<? extends Closeable> serverTransport, final int port,
+                                   final String name, final int maxBufferPoolSize, final int messageBufferSize) {
     this.name = name;
     this.port = port;
     this.serverSocket = RSocketFactory.receive()
@@ -47,7 +46,6 @@ public class RSocketServerChannelActor extends Actor implements ServerRequestRes
                                       .transport(serverTransport)
                                       .start()
                                       .block();
-
 
     if (this.serverSocket != null) {
       logger().info("RSocket server channel opened at port {}", this.port);
@@ -111,4 +109,35 @@ public class RSocketServerChannelActor extends Actor implements ServerRequestRes
     }
   }
 
+  public static class Instantiator implements ActorInstantiator<RSocketServerChannelActor> {
+    private static final long serialVersionUID = -1999865617618138682L;
+
+    private final RequestChannelConsumerProvider provider;
+    private final ServerTransport<? extends Closeable> serverTransport;
+    private final int port;
+    private final String name;
+    private final int maxBufferPoolSize;
+    private final int messageBufferSize;
+
+    public Instantiator(final RequestChannelConsumerProvider provider, final ServerTransport<? extends Closeable> serverTransport, final int port,
+                        final String name, final int maxBufferPoolSize, final int messageBufferSize) {
+
+      this.provider = provider;
+      this.serverTransport = serverTransport;
+      this.port = port;
+      this.name = name;
+      this.maxBufferPoolSize = maxBufferPoolSize;
+      this.messageBufferSize = messageBufferSize;
+    }
+
+    @Override
+    public RSocketServerChannelActor instantiate() {
+      return new RSocketServerChannelActor(provider, serverTransport, port, name, maxBufferPoolSize, messageBufferSize);
+    }
+
+    @Override
+    public Class<RSocketServerChannelActor> type() {
+      return RSocketServerChannelActor.class;
+    }
+  }
 }

--- a/src/test/java/io/vlingo/wire/fdx/bidirectional/BaseServerChannelTest.java
+++ b/src/test/java/io/vlingo/wire/fdx/bidirectional/BaseServerChannelTest.java
@@ -1,0 +1,233 @@
+// Copyright © 2012-2020 VLINGO LABS. All rights reserved.
+//
+// This Source Code Form is subject to the terms of the
+// Mozilla Public License, v. 2.0. If a copy of the MPL
+// was not distributed with this file, You can obtain
+// one at https://mozilla.org/MPL/2.0/.
+package io.vlingo.wire.fdx.bidirectional;
+
+import io.vlingo.actors.Definition;
+import io.vlingo.actors.Logger;
+import io.vlingo.actors.World;
+import io.vlingo.actors.testkit.TestUntil;
+import io.vlingo.wire.BaseWireTest;
+import io.vlingo.wire.channel.RequestChannelConsumerProvider;
+import io.vlingo.wire.message.ByteBufferAllocator;
+import io.vlingo.wire.node.Address;
+import io.vlingo.wire.node.AddressType;
+import io.vlingo.wire.node.Host;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.nio.ByteBuffer;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+
+public abstract class BaseServerChannelTest extends BaseWireTest {
+  private static final int POOL_SIZE = 100;
+
+  private ByteBuffer buffer;
+  private TestResponseChannelConsumer clientConsumer;
+  private TestRequestChannelConsumerProvider provider;
+  private TestRequestChannelConsumer serverConsumer;
+  private World world;
+  protected ClientRequestResponseChannel client;
+  protected ServerRequestResponseChannel server;
+
+  @Test
+  public void testBasicRequestResponse() throws Exception {
+    final String request = "Hello, Request-Response";
+
+    serverConsumer.currentExpectedRequestLength = request.length();
+    clientConsumer.currentExpectedResponseLength = serverConsumer.currentExpectedRequestLength;
+    request(request);
+
+    serverConsumer.untilConsume = TestUntil.happenings(1);
+    clientConsumer.untilConsume = TestUntil.happenings(1);
+
+    while (serverConsumer.untilConsume.remaining() > 0) {
+      ;
+    }
+    serverConsumer.untilConsume.completes();
+
+    while (clientConsumer.untilConsume.remaining() > 0) {
+      client.probeChannel();
+    }
+    clientConsumer.untilConsume.completes();
+
+    assertFalse(serverConsumer.requests.isEmpty());
+    assertEquals(1, serverConsumer.consumeCount);
+    assertEquals(serverConsumer.consumeCount, serverConsumer.requests.size());
+
+    assertFalse(clientConsumer.responses.isEmpty());
+    assertEquals(1, clientConsumer.consumeCount);
+    assertEquals(clientConsumer.consumeCount, clientConsumer.responses.size());
+
+    assertEquals(clientConsumer.responses.get(0), serverConsumer.requests.get(0));
+  }
+
+  @Test
+  public void testGappyRequestResponse() throws Exception {
+    final String requestPart1 = "Request Part-1";
+    final String requestPart2 = ":Request Part-2";
+    final String requestPart3 = ":Request Part-3";
+
+    serverConsumer.currentExpectedRequestLength = requestPart1.length() + requestPart2.length() + requestPart3.length();
+    clientConsumer.currentExpectedResponseLength = serverConsumer.currentExpectedRequestLength;
+
+    // simulate network latency for parts of single request
+    serverConsumer.untilConsume = TestUntil.happenings(1);
+    clientConsumer.untilConsume = TestUntil.happenings(1);
+
+    request(requestPart1);
+    Thread.sleep(100);
+    request(requestPart2);
+    Thread.sleep(200);
+    request(requestPart3);
+    while (serverConsumer.untilConsume.remaining() > 0) {
+      ;
+    }
+    serverConsumer.untilConsume.completes();
+
+    while (clientConsumer.untilConsume.remaining() > 0) {
+      Thread.sleep(10);
+      client.probeChannel();
+    }
+    clientConsumer.untilConsume.completes();
+
+    assertFalse(serverConsumer.requests.isEmpty());
+    assertEquals(1, serverConsumer.consumeCount);
+    assertEquals(serverConsumer.consumeCount, serverConsumer.requests.size());
+
+    assertFalse(clientConsumer.responses.isEmpty());
+    assertEquals(1, clientConsumer.consumeCount);
+    assertEquals(clientConsumer.consumeCount, clientConsumer.responses.size());
+
+    assertEquals(clientConsumer.responses.get(0), serverConsumer.requests.get(0));
+  }
+
+  @Test
+  public void test10RequestResponse() throws Exception {
+    final String request = "Hello, Request-Response";
+
+    serverConsumer.currentExpectedRequestLength = request.length() + 1; // digits 0 - 9
+    clientConsumer.currentExpectedResponseLength = serverConsumer.currentExpectedRequestLength;
+
+    serverConsumer.untilConsume = TestUntil.happenings(10);
+    clientConsumer.untilConsume = TestUntil.happenings(10);
+
+    for (int idx = 0; idx < 10; ++idx) {
+      request(request + idx);
+    }
+
+    while (clientConsumer.untilConsume.remaining() > 0) {
+      client.probeChannel();
+    }
+
+    serverConsumer.untilConsume.completes();
+    clientConsumer.untilConsume.completes();
+
+    assertFalse(serverConsumer.requests.isEmpty());
+    assertEquals(10, serverConsumer.consumeCount);
+    assertEquals(serverConsumer.consumeCount, serverConsumer.requests.size());
+
+    assertFalse(clientConsumer.responses.isEmpty());
+    assertEquals(10, clientConsumer.consumeCount);
+    assertEquals(clientConsumer.consumeCount, clientConsumer.responses.size());
+
+    for (int idx = 0; idx < 10; ++idx) {
+      assertEquals(clientConsumer.responses.get(idx), serverConsumer.requests.get(idx));
+    }
+  }
+
+  @Test
+  public void testThatRequestResponsePoolLimitsNotExceeded() throws Exception {
+    final int TOTAL = POOL_SIZE * 2;
+
+    final String request = "Hello, Request-Response";
+
+    serverConsumer.currentExpectedRequestLength = request.length() + 3; // digits 000 - 999
+    clientConsumer.currentExpectedResponseLength = serverConsumer.currentExpectedRequestLength;
+
+    serverConsumer.untilConsume = TestUntil.happenings(TOTAL);
+    clientConsumer.untilConsume = TestUntil.happenings(TOTAL);
+
+    for (int idx = 0; idx < TOTAL; ++idx) {
+      request(request + String.format("%03d", idx));
+    }
+
+    while (clientConsumer.untilConsume.remaining() > 0) {
+      client.probeChannel();
+    }
+    serverConsumer.untilConsume.completes();
+    clientConsumer.untilConsume.completes();
+
+    assertFalse(serverConsumer.requests.isEmpty());
+    assertEquals(TOTAL, serverConsumer.consumeCount);
+    assertEquals(serverConsumer.consumeCount, serverConsumer.requests.size());
+
+    assertFalse(clientConsumer.responses.isEmpty());
+    assertEquals(TOTAL, clientConsumer.consumeCount);
+    assertEquals(clientConsumer.consumeCount, clientConsumer.responses.size());
+
+    for (int idx = 0; idx < TOTAL; ++idx) {
+      assertEquals(clientConsumer.responses.get(idx), serverConsumer.requests.get(idx));
+    }
+  }
+
+  protected void request(final String request) {
+    buffer.clear();
+    buffer.put(request.getBytes());
+    buffer.flip();
+    client.requestWith(buffer);
+  }
+
+  @Before
+  public final void setUp() throws Exception {
+    world = World.startWithDefaults("test-request-response-channel");
+
+    buffer = ByteBufferAllocator.allocate(1024);
+    final Logger logger = Logger.basicLogger();
+    provider = new TestRequestChannelConsumerProvider();
+    serverConsumer = (TestRequestChannelConsumer) provider.consumer;
+
+    final int testPort = getNextTestPort();
+
+    final Definition definition = getServerDefinition(provider, testPort, POOL_SIZE, 10240);
+    server = world.actorFor(ServerRequestResponseChannel.class, definition);
+
+    clientConsumer = new TestResponseChannelConsumer();
+
+    client = getClient(logger, testPort, clientConsumer, POOL_SIZE, 10240);
+  }
+
+  @After
+  public void tearDown() {
+    server.close();
+    client.close();
+
+    try {
+      Thread.sleep(1000);
+    } catch (Exception e) {
+    }
+
+    world.terminate();
+  }
+
+  protected abstract int getNextTestPort();
+
+  protected abstract Definition getServerDefinition(final RequestChannelConsumerProvider provider, final int port, final int maxBufferPoolSize,
+                                                    final int maxMessageSize);
+
+  protected ClientRequestResponseChannel getClient(final Logger logger, final int testPort, final TestResponseChannelConsumer clientConsumer,
+                                                   final int maxBufferPoolSize, final int maxMessageSize) throws Exception {
+    return new BasicClientRequestResponseChannel(Address.from(Host.of("localhost"), testPort, AddressType.NONE),
+                                                 clientConsumer,
+                                                 maxBufferPoolSize,
+                                                 maxMessageSize,
+                                                 logger);
+  }
+
+}

--- a/src/test/java/io/vlingo/wire/fdx/bidirectional/SocketRequestResponseChannelTest.java
+++ b/src/test/java/io/vlingo/wire/fdx/bidirectional/SocketRequestResponseChannelTest.java
@@ -7,219 +7,32 @@
 
 package io.vlingo.wire.fdx.bidirectional;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
+import io.vlingo.actors.Definition;
+import io.vlingo.wire.channel.RequestChannelConsumerProvider;
+import io.vlingo.wire.fdx.bidirectional.ServerRequestResponseChannel.ServerRequestResponseChannelInstantiator;
 
-import java.nio.ByteBuffer;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-
-import io.vlingo.actors.Logger;
-import io.vlingo.actors.World;
-import io.vlingo.actors.testkit.TestUntil;
-import io.vlingo.wire.BaseWireTest;
-import io.vlingo.wire.message.ByteBufferAllocator;
-import io.vlingo.wire.node.Address;
-import io.vlingo.wire.node.AddressType;
-import io.vlingo.wire.node.Host;
-
-public class SocketRequestResponseChannelTest extends BaseWireTest {
-  private static final int POOL_SIZE = 100;
+public class SocketRequestResponseChannelTest extends BaseServerChannelTest {
   private static AtomicInteger TEST_PORT = new AtomicInteger(37370);
 
-  private ByteBuffer buffer;
-  private ClientRequestResponseChannel client;
-  private TestResponseChannelConsumer clientConsumer;
-  private TestRequestChannelConsumerProvider provider;
-  private ServerRequestResponseChannel server;
-  private TestRequestChannelConsumer serverConsumer;
-  private World world;
-
-  @Test
-  public void testBasicRequestResponse() throws Exception {
-    final String request = "Hello, Request-Response";
-
-    serverConsumer.currentExpectedRequestLength = request.length();
-    clientConsumer.currentExpectedResponseLength = serverConsumer.currentExpectedRequestLength;
-    request(request);
-
-    serverConsumer.untilConsume = TestUntil.happenings(1);
-    clientConsumer.untilConsume = TestUntil.happenings(1);
-
-    while (serverConsumer.untilConsume.remaining() > 0) {
-      ;
-    }
-    serverConsumer.untilConsume.completes();
-
-    while (clientConsumer.untilConsume.remaining() > 0) {
-      client.probeChannel();
-    }
-    clientConsumer.untilConsume.completes();
-
-    assertFalse(serverConsumer.requests.isEmpty());
-    assertEquals(1, serverConsumer.consumeCount);
-    assertEquals(serverConsumer.consumeCount, serverConsumer.requests.size());
-
-    assertFalse(clientConsumer.responses.isEmpty());
-    assertEquals(1, clientConsumer.consumeCount);
-    assertEquals(clientConsumer.consumeCount, clientConsumer.responses.size());
-
-    assertEquals(clientConsumer.responses.get(0), serverConsumer.requests.get(0));
+  @Override
+  protected int getNextTestPort() {
+    return TEST_PORT.incrementAndGet();
   }
 
-  @Test
-  public void testGappyRequestResponse() throws Exception {
-    final String requestPart1 = "Request Part-1";
-    final String requestPart2 = ":Request Part-2";
-    final String requestPart3 = ":Request Part-3";
-
-    serverConsumer.currentExpectedRequestLength = requestPart1.length() + requestPart2.length() + requestPart3.length();
-    clientConsumer.currentExpectedResponseLength = serverConsumer.currentExpectedRequestLength;
-
-    // simulate network latency for parts of single request
-
-    request(requestPart1);
-    Thread.sleep(100);
-    request(requestPart2);
-    Thread.sleep(200);
-    request(requestPart3);
-    serverConsumer.untilConsume = TestUntil.happenings(1);
-    while (serverConsumer.untilConsume.remaining() > 0) {
-      ;
-    }
-    serverConsumer.untilConsume.completes();
-
-    clientConsumer.untilConsume = TestUntil.happenings(1);
-    while (clientConsumer.untilConsume.remaining() > 0) {
-      Thread.sleep(10);
-      client.probeChannel();
-    }
-    clientConsumer.untilConsume.completes();
-
-    assertFalse(serverConsumer.requests.isEmpty());
-    assertEquals(1, serverConsumer.consumeCount);
-    assertEquals(serverConsumer.consumeCount, serverConsumer.requests.size());
-
-    assertFalse(clientConsumer.responses.isEmpty());
-    assertEquals(1, clientConsumer.consumeCount);
-    assertEquals(clientConsumer.consumeCount, clientConsumer.responses.size());
-
-    assertEquals(clientConsumer.responses.get(0), serverConsumer.requests.get(0));
+  @Override
+  protected Definition getServerDefinition(final RequestChannelConsumerProvider provider, final int port, final int maxBufferPoolSize,
+                                           final int maxMessageSize) {
+    final ServerRequestResponseChannelInstantiator instantiator = new ServerRequestResponseChannelInstantiator(provider,
+                                                                                                               port,
+                                                                                                               "test-server",
+                                                                                                               1,
+                                                                                                               maxBufferPoolSize,
+                                                                                                               maxMessageSize,
+                                                                                                               10L,
+                                                                                                               2L);
+    return Definition.has(ServerRequestResponseChannelActor.class, instantiator);
   }
 
-  @Test
-  public void test10RequestResponse() throws Exception {
-    final String request = "Hello, Request-Response";
-
-    serverConsumer.currentExpectedRequestLength = request.length() + 1; // digits 0 - 9
-    clientConsumer.currentExpectedResponseLength = serverConsumer.currentExpectedRequestLength;
-
-    serverConsumer.untilConsume = TestUntil.happenings(10);
-    clientConsumer.untilConsume = TestUntil.happenings(10);
-
-    for (int idx = 0; idx < 10; ++idx) {
-      request(request + idx);
-    }
-
-    while (clientConsumer.untilConsume.remaining() > 0) {
-      client.probeChannel();
-    }
-
-    serverConsumer.untilConsume.completes();
-    clientConsumer.untilConsume.completes();
-
-    assertFalse(serverConsumer.requests.isEmpty());
-    assertEquals(10, serverConsumer.consumeCount);
-    assertEquals(serverConsumer.consumeCount, serverConsumer.requests.size());
-
-    assertFalse(clientConsumer.responses.isEmpty());
-    assertEquals(10, clientConsumer.consumeCount);
-    assertEquals(clientConsumer.consumeCount, clientConsumer.responses.size());
-
-    for (int idx = 0; idx < 10; ++idx) {
-      assertEquals(clientConsumer.responses.get(idx), serverConsumer.requests.get(idx));
-    }
-  }
-
-  @Test
-  public void testThatRequestResponsePoolLimitsNotExceeded() throws Exception {
-    final int TOTAL = POOL_SIZE * 2;
-
-    final String request = "Hello, Request-Response";
-
-    serverConsumer.currentExpectedRequestLength = request.length() + 3; // digits 000 - 999
-    clientConsumer.currentExpectedResponseLength = serverConsumer.currentExpectedRequestLength;
-
-    serverConsumer.untilConsume = TestUntil.happenings(TOTAL);
-    clientConsumer.untilConsume = TestUntil.happenings(TOTAL);
-
-    for (int idx = 0; idx < TOTAL; ++idx) {
-      request(request + String.format("%03d", idx));
-    }
-
-    while (clientConsumer.untilConsume.remaining() > 0) {
-      client.probeChannel();
-    }
-    serverConsumer.untilConsume.completes();
-    clientConsumer.untilConsume.completes();
-
-    assertFalse(serverConsumer.requests.isEmpty());
-    assertEquals(TOTAL, serverConsumer.consumeCount);
-    assertEquals(serverConsumer.consumeCount, serverConsumer.requests.size());
-
-    assertFalse(clientConsumer.responses.isEmpty());
-    assertEquals(TOTAL, clientConsumer.consumeCount);
-    assertEquals(clientConsumer.consumeCount, clientConsumer.responses.size());
-
-    for (int idx = 0; idx < TOTAL; ++idx) {
-      assertEquals(clientConsumer.responses.get(idx), serverConsumer.requests.get(idx));
-    }
-  }
-
-  @Before
-  public void setUp() throws Exception {
-    world = World.startWithDefaults("test-request-response-channel");
-
-    buffer = ByteBufferAllocator.allocate(1024);
-    final Logger logger = Logger.basicLogger();
-    provider = new TestRequestChannelConsumerProvider();
-    serverConsumer = (TestRequestChannelConsumer) provider.consumer;
-
-    final int testPort = TEST_PORT.incrementAndGet();
-
-    server = ServerRequestResponseChannel.start(
-                    world.stage(),
-                    provider,
-                    testPort,
-                    "test-server",
-                    1,
-                    POOL_SIZE,
-                    10240,
-                    10L,
-                    2L);
-
-    clientConsumer = new TestResponseChannelConsumer();
-
-    client = new BasicClientRequestResponseChannel(Address.from(Host.of("localhost"), testPort,  AddressType.NONE), clientConsumer, POOL_SIZE, 10240, logger);
-  }
-
-  @After
-  public void tearDown() {
-    server.close();
-    client.close();
-
-    try { Thread.sleep(1000); } catch (Exception e) {  }
-
-    world.terminate();
-  }
-
-  private void request(final String request) {
-    buffer.clear();
-    buffer.put(request.getBytes());
-    buffer.flip();
-    client.requestWith(buffer);
-  }
 }

--- a/src/test/java/io/vlingo/wire/fdx/bidirectional/netty/server/NettyServerChannelActorTest.java
+++ b/src/test/java/io/vlingo/wire/fdx/bidirectional/netty/server/NettyServerChannelActorTest.java
@@ -1,0 +1,32 @@
+// Copyright © 2012-2020 VLINGO LABS. All rights reserved.
+//
+// This Source Code Form is subject to the terms of the
+// Mozilla Public License, v. 2.0. If a copy of the MPL
+// was not distributed with this file, You can obtain
+// one at https://mozilla.org/MPL/2.0/.
+package io.vlingo.wire.fdx.bidirectional.netty.server;
+
+import io.vlingo.actors.Definition;
+import io.vlingo.wire.channel.RequestChannelConsumerProvider;
+import io.vlingo.wire.fdx.bidirectional.BaseServerChannelTest;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class NettyServerChannelActorTest extends BaseServerChannelTest {
+  private static AtomicInteger TEST_PORT = new AtomicInteger(37370);
+
+  @Override
+  protected int getNextTestPort() {
+    return TEST_PORT.getAndIncrement();
+  }
+
+  @Override
+  protected Definition getServerDefinition(final RequestChannelConsumerProvider provider, final int port, final int maxBufferPoolSize, final int maxMessageSize) {
+    final NettyServerChannelActor.Instantiator instantiator = new NettyServerChannelActor.Instantiator(provider,
+                                                                                                       port,
+                                                                                                       "netty-test-server",
+                                                                                                       1, maxBufferPoolSize,
+                                                                                                       maxMessageSize);
+    return Definition.has(NettyServerChannelActor.class, instantiator);
+  }
+}

--- a/src/test/java/io/vlingo/wire/fdx/bidirectional/rsocket/RSocketServerChannelActorTest.java
+++ b/src/test/java/io/vlingo/wire/fdx/bidirectional/rsocket/RSocketServerChannelActorTest.java
@@ -11,231 +11,55 @@ import io.rsocket.transport.local.LocalClientTransport;
 import io.rsocket.transport.local.LocalServerTransport;
 import io.vlingo.actors.Definition;
 import io.vlingo.actors.Logger;
-import io.vlingo.actors.World;
-import io.vlingo.actors.testkit.TestUntil;
+import io.vlingo.wire.channel.RequestChannelConsumerProvider;
+import io.vlingo.wire.fdx.bidirectional.BaseServerChannelTest;
 import io.vlingo.wire.fdx.bidirectional.ClientRequestResponseChannel;
-import io.vlingo.wire.fdx.bidirectional.ServerRequestResponseChannel;
-import io.vlingo.wire.fdx.bidirectional.ServerRequestResponseChannel.RSocketServerRequestResponseChannelInstantiator;
-import io.vlingo.wire.fdx.bidirectional.TestRequestChannelConsumer;
-import io.vlingo.wire.fdx.bidirectional.TestRequestChannelConsumerProvider;
 import io.vlingo.wire.fdx.bidirectional.TestResponseChannelConsumer;
 import io.vlingo.wire.node.Address;
 import io.vlingo.wire.node.AddressType;
 import io.vlingo.wire.node.Host;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
 
 import java.nio.ByteBuffer;
 import java.time.Duration;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
+public class RSocketServerChannelActorTest extends BaseServerChannelTest {
+  private final LocalServerTransport serverTransport = LocalServerTransport.create("rsocket-fdx-server-test");
+  private final ClientTransport clientTransport = LocalClientTransport.create("rsocket-fdx-server-test");
 
-public class RSocketServerChannelActorTest {
-  private static final int POOL_SIZE = 100;
-
-  private ClientRequestResponseChannel client;
-  private TestResponseChannelConsumer clientConsumer;
-  private TestRequestChannelConsumerProvider provider;
-  private ServerRequestResponseChannel server;
-  private TestRequestChannelConsumer serverConsumer;
-  private World world;
-  
-  @Test
-  public void testBasicRequestResponse() throws Exception {
-    final String request = "Hello, Request-Response";
-
-    serverConsumer.currentExpectedRequestLength = request.length();
-    clientConsumer.currentExpectedResponseLength = serverConsumer.currentExpectedRequestLength;
-    request(request);
-
-    serverConsumer.untilConsume = TestUntil.happenings(1);
-    clientConsumer.untilConsume = TestUntil.happenings(1);
-
-    while (serverConsumer.untilConsume.remaining() > 0) {
-      ;
-    }
-    serverConsumer.untilConsume.completes();
-
-    while (clientConsumer.untilConsume.remaining() > 0) {
-      client.probeChannel();
-    }
-    clientConsumer.untilConsume.completes();
-
-    assertFalse(serverConsumer.requests.isEmpty());
-    assertEquals(1, serverConsumer.consumeCount);
-    assertEquals(serverConsumer.consumeCount, serverConsumer.requests.size());
-
-    assertFalse(clientConsumer.responses.isEmpty());
-    assertEquals(1, clientConsumer.consumeCount);
-    assertEquals(clientConsumer.consumeCount, clientConsumer.responses.size());
-
-    assertEquals(clientConsumer.responses.get(0), serverConsumer.requests.get(0));
+  @Override
+  protected int getNextTestPort() {
+    return 0;
   }
 
-  @Test
-  public void testGappyRequestResponse() throws Exception {
-    final String requestPart1 = "Request Part-1";
-    final String requestPart2 = ":Request Part-2";
-    final String requestPart3 = ":Request Part-3";
+  @Override
+  protected Definition getServerDefinition(final RequestChannelConsumerProvider provider, final int port, final int maxBufferPoolSize,
+                                           final int maxMessageSize) {
+    final RSocketServerChannelActor.Instantiator instantiator = new RSocketServerChannelActor.Instantiator(provider,
+                                                                                                           serverTransport,
+                                                                                                           0,
+                                                                                                           "test-server",
+                                                                                                           maxBufferPoolSize,
+                                                                                                           maxMessageSize);
 
-    serverConsumer.currentExpectedRequestLength = requestPart1.length() + requestPart2.length() + requestPart3.length();
-    clientConsumer.currentExpectedResponseLength = serverConsumer.currentExpectedRequestLength;
-
-    // simulate network latency for parts of single request
-    clientConsumer.untilConsume = TestUntil.happenings(1);
-    serverConsumer.untilConsume = TestUntil.happenings(1);
-
-    request(requestPart1);
-    Thread.sleep(100);
-    request(requestPart2);
-    Thread.sleep(200);
-    request(requestPart3);
-    while (serverConsumer.untilConsume.remaining() > 0) {
-      ;
-    }
-    serverConsumer.untilConsume.completes();
-
-    while (clientConsumer.untilConsume.remaining() > 0) {
-      Thread.sleep(10);
-      client.probeChannel();
-    }
-    clientConsumer.untilConsume.completes();
-
-    assertFalse(serverConsumer.requests.isEmpty());
-    assertEquals(1, serverConsumer.consumeCount);
-    assertEquals(serverConsumer.consumeCount, serverConsumer.requests.size());
-
-    assertFalse(clientConsumer.responses.isEmpty());
-    assertEquals(1, clientConsumer.consumeCount);
-    assertEquals(clientConsumer.consumeCount, clientConsumer.responses.size());
-
-    assertEquals(clientConsumer.responses.get(0), serverConsumer.requests.get(0));
+    return Definition.has(RSocketServerChannelActor.class, instantiator);
   }
 
-
-  @Test
-  public void test10RequestResponse() throws Exception {
-    final String request = "Hello, Request-Response";
-
-    serverConsumer.currentExpectedRequestLength = request.length() + 1; // digits 0 - 9
-    clientConsumer.currentExpectedResponseLength = serverConsumer.currentExpectedRequestLength;
-
-    serverConsumer.untilConsume = TestUntil.happenings(10);
-    clientConsumer.untilConsume = TestUntil.happenings(10);
-
-    for (int idx = 0; idx < 10; ++idx) {
-      request(request + idx);
-    }
-
-    while (clientConsumer.untilConsume.remaining() > 0) {
-      client.probeChannel();
-    }
-
-    serverConsumer.untilConsume.completes();
-    clientConsumer.untilConsume.completes();
-
-    assertFalse(serverConsumer.requests.isEmpty());
-    assertEquals(10, serverConsumer.consumeCount);
-    assertEquals(serverConsumer.consumeCount, serverConsumer.requests.size());
-
-    assertFalse(clientConsumer.responses.isEmpty());
-    assertEquals(10, clientConsumer.consumeCount);
-    assertEquals(clientConsumer.consumeCount, clientConsumer.responses.size());
-
-    for (int idx = 0; idx < 10; ++idx) {
-      assertEquals(clientConsumer.responses.get(idx), serverConsumer.requests.get(idx));
-    }
-  }
-
-  @Test
-  public void testThatRequestResponsePoolLimitsNotExceeded() throws Exception {
-    final int TOTAL = POOL_SIZE * 2;
-
-    final String request = "Hello, Request-Response";
-
-    serverConsumer.currentExpectedRequestLength = request.length() + 3; // digits 000 - 999
-    clientConsumer.currentExpectedResponseLength = serverConsumer.currentExpectedRequestLength;
-
-    serverConsumer.untilConsume = TestUntil.happenings(TOTAL);
-    clientConsumer.untilConsume = TestUntil.happenings(TOTAL);
-
-    for (int idx = 0; idx < TOTAL; ++idx) {
-      request(request + String.format("%03d", idx));
-    }
-
-    while (clientConsumer.untilConsume.remaining() > 0) {
-      client.probeChannel();
-    }
-    serverConsumer.untilConsume.completes();
-    clientConsumer.untilConsume.completes();
-
-    assertFalse(serverConsumer.requests.isEmpty());
-    assertEquals(TOTAL, serverConsumer.consumeCount);
-    assertEquals(serverConsumer.consumeCount, serverConsumer.requests.size());
-
-    assertFalse(clientConsumer.responses.isEmpty());
-    assertEquals(TOTAL, clientConsumer.consumeCount);
-    assertEquals(clientConsumer.consumeCount, clientConsumer.responses.size());
-
-    for (int idx = 0; idx < TOTAL; ++idx) {
-      assertEquals(clientConsumer.responses.get(idx), serverConsumer.requests.get(idx));
-    }
-  }
-
-  @Before
-  public void setUp() throws Exception {
-    world = World.startWithDefaults("test-request-response-channel");
-
-    final Logger logger = Logger.basicLogger();
-    provider = new TestRequestChannelConsumerProvider();
-    serverConsumer = (TestRequestChannelConsumer) provider.consumer;
-
-    final ClientTransport clientTransport = LocalClientTransport.create("rsocket-fdx-server-test");
-    final LocalServerTransport serverTransport = LocalServerTransport.create("rsocket-fdx-server-test");
-
-    final RSocketServerRequestResponseChannelInstantiator instantiator =
-            new RSocketServerRequestResponseChannelInstantiator(provider, serverTransport, 0, "test-server", POOL_SIZE, 10240);
-
-    server = world.actorFor(
-                    ServerRequestResponseChannel.class,
-                    Definition.has(RSocketServerChannelActor.class, instantiator));
-
+  @Override
+  protected ClientRequestResponseChannel getClient(final Logger logger, final int testPort, final TestResponseChannelConsumer clientConsumer,
+                                                   final int maxBufferPoolSize, final int maxMessageSize) throws Exception {
     final Integer serverPort = server.port().<Integer>await();
 
-    assertNotNull("Server failed to start", serverPort);
-
-    clientConsumer = new TestResponseChannelConsumer();
-
-    client = new RSocketClientChannel(clientTransport, Address.from(Host.of("127.0.0.1"), serverPort, AddressType.NONE),
-                                      clientConsumer, POOL_SIZE, 10240, logger, Duration.ofSeconds(1));
+    return new RSocketClientChannel(clientTransport,
+                                    Address.from(Host.of("127.0.0.1"), serverPort, AddressType.NONE),
+                                    clientConsumer,
+                                    maxBufferPoolSize,
+                                    maxMessageSize,
+                                    logger,
+                                    Duration.ofSeconds(1));
   }
 
-  @After
-  public void tearDown() {
-    try {
-      server.close();
-    } catch (Exception e) {
-      // ignore
-    }
-    try {
-      client.close();
-    } catch (Exception e) {
-      // ignore
-    }
-
-    try { Thread.sleep(1000); } catch (Exception e) {  }
-
-    try {
-      world.terminate();
-    } catch (Exception e) {
-      // ignore
-    }
-  }
-
-  private void request(final String request) {
+  @Override
+  protected void request(final String request) {
     client.requestWith(ByteBuffer.wrap(request.getBytes()));
   }
 


### PR DESCRIPTION
Initial version.

Netty documentation: https://netty.io/wiki/user-guide-for-4.x.html


In order to use Netty based implementation, use `ServerRequestResponseChannel.startWithNetty`