### PR TITLE
Fixes for issue #35

### DIFF
--- a/src/test/java/io/vlingo/wire/fdx/bidirectional/BaseServerChannelTest.java
+++ b/src/test/java/io/vlingo/wire/fdx/bidirectional/BaseServerChannelTest.java
@@ -42,11 +42,11 @@ public abstract class BaseServerChannelTest extends BaseWireTest {
 
     serverConsumer.currentExpectedRequestLength = request.length();
     clientConsumer.currentExpectedResponseLength = serverConsumer.currentExpectedRequestLength;
-    request(request);
-
     serverConsumer.untilConsume = TestUntil.happenings(1);
     clientConsumer.untilConsume = TestUntil.happenings(1);
 
+    request(request);
+    
     while (serverConsumer.untilConsume.remaining() > 0) {
       ;
     }


### PR DESCRIPTION
`clientConsumer.untilConsume` and `serverConsumer.untilConsume` should be initialized before sending the request