### PR TITLE
Netty graceful shutdown configuration

### DIFF
--- a/src/main/java/io/vlingo/wire/fdx/bidirectional/rsocket/RSocketServerChannelActor.java
+++ b/src/main/java/io/vlingo/wire/fdx/bidirectional/rsocket/RSocketServerChannelActor.java
@@ -60,15 +60,6 @@ public class RSocketServerChannelActor extends Actor implements ServerRequestRes
   public void close() {
     if (isStopped())
       return;
-
-    if (this.serverSocket != null) {
-      try {
-        this.serverSocket.dispose();
-      } catch (final Exception e) {
-        logger().error("Failed to close receive socket for: {}", name, e);
-      }
-    }
-
     selfAs(Stoppable.class).stop();
   }
 
@@ -79,6 +70,14 @@ public class RSocketServerChannelActor extends Actor implements ServerRequestRes
 
   @Override
   public void stop() {
+    if (this.serverSocket != null) {
+      try {
+        this.serverSocket.dispose();
+      } catch (final Exception e) {
+        logger().error("Failed to close receive socket for: {}", name, e);
+      }
+    }
+
     super.stop();
   }
 

--- a/src/test/java/io/vlingo/wire/fdx/bidirectional/BaseServerChannelTest.java
+++ b/src/test/java/io/vlingo/wire/fdx/bidirectional/BaseServerChannelTest.java
@@ -18,6 +18,7 @@ import io.vlingo.wire.node.Address;
 import io.vlingo.wire.node.AddressType;
 import io.vlingo.wire.node.Host;
 import org.junit.After;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -177,6 +178,15 @@ public abstract class BaseServerChannelTest extends BaseWireTest {
     for (int idx = 0; idx < TOTAL; ++idx) {
       assertEquals(clientConsumer.responses.get(idx), serverConsumer.requests.get(idx));
     }
+  }
+
+  @Test
+  public void testServerStops() throws InterruptedException {
+    this.server.stop();
+
+    Thread.sleep(300);
+
+    Assert.assertTrue(this.server.isStopped());
   }
 
   protected void request(final String request) {


### PR DESCRIPTION
By default, netty resources can take up to 2 seconds to shutdown gracefully.
This PR allows to configure `NettyServerChannelActor` with graceful shutdown quite period and timeout configurable.

With the default values, the Netty resources will be shutdown imediatelly.