### PR TITLE
Configurable graceful shutdown for the Netty client

### DIFF
--- a/src/main/java/io/vlingo/wire/fdx/bidirectional/netty/server/NettyServerChannelActor.java
+++ b/src/main/java/io/vlingo/wire/fdx/bidirectional/netty/server/NettyServerChannelActor.java
@@ -152,7 +152,7 @@ public class NettyServerChannelActor extends Actor implements ServerRequestRespo
      */
     public Instantiator(final RequestChannelConsumerProvider provider, final int port, final String name, final int processorPoolSize,
                         final int maxBufferPoolSize, final int maxMessageSize) {
-      this(provider, port, name, processorPoolSize, maxBufferPoolSize, maxMessageSize, Duration.ofMillis(0), Duration.ofMillis(0));
+      this(provider, port, name, processorPoolSize, maxBufferPoolSize, maxMessageSize, Duration.ZERO, Duration.ZERO);
     }
 
     /**

--- a/src/test/java/io/vlingo/wire/fdx/bidirectional/BaseServerChannelTest.java
+++ b/src/test/java/io/vlingo/wire/fdx/bidirectional/BaseServerChannelTest.java
@@ -49,7 +49,7 @@ public abstract class BaseServerChannelTest extends BaseWireTest {
     clientConsumer.untilConsume = TestUntil.happenings(1);
 
     request(request);
-    
+
     while (serverConsumer.untilConsume.remaining() > 0) {
       ;
     }
@@ -240,7 +240,9 @@ public abstract class BaseServerChannelTest extends BaseWireTest {
                                                  clientConsumer,
                                                  maxBufferPoolSize,
                                                  maxMessageSize,
-                                                 Duration.ofMillis(1000));
+                                                 Duration.ofMillis(1000),
+                                                 Duration.ZERO,
+                                                 Duration.ZERO);
   }
 
 }

--- a/src/test/java/io/vlingo/wire/fdx/bidirectional/netty/client/NettyClientRequestResponseChannelTest.java
+++ b/src/test/java/io/vlingo/wire/fdx/bidirectional/netty/client/NettyClientRequestResponseChannelTest.java
@@ -46,7 +46,8 @@ public class NettyClientRequestResponseChannelTest {
 
     final Address address = Address.from(Host.of("localhost"), 8080, AddressType.MAIN);
 
-    final NettyClientRequestResponseChannel clientChannel = new NettyClientRequestResponseChannel(address, consumer, 1, 1, Duration.ofMillis(10));
+    final NettyClientRequestResponseChannel clientChannel = new NettyClientRequestResponseChannel(address, consumer, 1, 1, Duration.ofMillis(10),
+                                                                                                  Duration.ofMillis(1), Duration.ofMillis(1));
 
     try {
       clientChannel.requestWith(ByteBuffer.wrap(UUID.randomUUID()


### PR DESCRIPTION
 By default it's disabled.