### PR TITLE
Eliminate bare test until uses

### DIFF
--- a/src/test/java/io/vlingo/wire/fdx/bidirectional/BaseServerChannelTest.java
+++ b/src/test/java/io/vlingo/wire/fdx/bidirectional/BaseServerChannelTest.java
@@ -4,6 +4,7 @@
 // Mozilla Public License, v. 2.0. If a copy of the MPL
 // was not distributed with this file, You can obtain
 // one at https://mozilla.org/MPL/2.0/.
+
 package io.vlingo.wire.fdx.bidirectional;
 
 import io.vlingo.actors.Definition;

--- a/src/test/java/io/vlingo/wire/fdx/bidirectional/TestRequestChannelConsumerProvider.java
+++ b/src/test/java/io/vlingo/wire/fdx/bidirectional/TestRequestChannelConsumerProvider.java
@@ -1,11 +1,12 @@
 package io.vlingo.wire.fdx.bidirectional;
 
-import io.vlingo.actors.testkit.TestUntil;
 import io.vlingo.wire.channel.RequestChannelConsumer;
 import io.vlingo.wire.channel.RequestChannelConsumerProvider;
 
+import static io.vlingo.wire.fdx.bidirectional.TestRequestChannelConsumer.*;
+
 public class TestRequestChannelConsumerProvider implements RequestChannelConsumerProvider {
-  public TestUntil until;
+  public State state;
   public RequestChannelConsumer consumer = new TestRequestChannelConsumer();
 
   @Override

--- a/src/test/java/io/vlingo/wire/fdx/bidirectional/TestResponseChannelConsumer.java
+++ b/src/test/java/io/vlingo/wire/fdx/bidirectional/TestResponseChannelConsumer.java
@@ -57,7 +57,7 @@ public class TestResponseChannelConsumer implements ResponseChannelConsumer {
   }
 
   public static class State {
-    AccessSafely access;
+    public AccessSafely access;
     AtomicInteger consumeCount = new AtomicInteger(0);
     AtomicInteger remaining;
 
@@ -76,8 +76,8 @@ public class TestResponseChannelConsumer implements ResponseChannelConsumer {
     }
 
     private void increment() {
-      consumeCount.set(consumeCount.incrementAndGet());
-      remaining.set(remaining.decrementAndGet());
+      consumeCount.incrementAndGet();
+      remaining.decrementAndGet();
     }
   }
 }

--- a/src/test/java/io/vlingo/wire/fdx/bidirectional/TestResponseChannelConsumer.java
+++ b/src/test/java/io/vlingo/wire/fdx/bidirectional/TestResponseChannelConsumer.java
@@ -7,19 +7,20 @@
 
 package io.vlingo.wire.fdx.bidirectional;
 
-import io.vlingo.actors.testkit.TestUntil;
+import io.vlingo.actors.testkit.AccessSafely;
 import io.vlingo.wire.channel.ResponseChannelConsumer;
 import io.vlingo.wire.message.ConsumerByteBuffer;
 import io.vlingo.wire.message.Converters;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
 
 public class TestResponseChannelConsumer implements ResponseChannelConsumer {
   public int currentExpectedResponseLength;
   public int consumeCount;
   public List<String> responses = new ArrayList<>();
-  public TestUntil untilConsume;
+  public State state;
 
   private final StringBuilder responseBuilder = new StringBuilder();
 
@@ -40,7 +41,7 @@ public class TestResponseChannelConsumer implements ResponseChannelConsumer {
         currentIndex += currentExpectedResponseLength;
 
         responses.add(request);
-        ++consumeCount;
+        state.access.writeUsing("consumeCount", 1);
 
         responseBuilder.setLength(0); // reuse
         if (currentIndex + currentExpectedResponseLength > combinedLength) {
@@ -51,8 +52,32 @@ public class TestResponseChannelConsumer implements ResponseChannelConsumer {
         } else {
           last = currentIndex == combinedLength;
         }
-        untilConsume.happened();
       }
     } buffer.release();
+  }
+
+  public static class State {
+    AccessSafely access;
+    AtomicInteger consumeCount = new AtomicInteger(0);
+    AtomicInteger remaining;
+
+    public State(final int totalWrites) {
+      this.remaining = new AtomicInteger(totalWrites);
+      this.access = afterCompleting(totalWrites);
+    }
+
+    private AccessSafely afterCompleting(final int totalWrites) {
+      access = AccessSafely
+              .afterCompleting(totalWrites)
+              .writingWith("consumeCount", (Integer increment) -> increment())
+              .readingWith("consumeCount", consumeCount::get)
+              .readingWith("remaining", remaining::get);
+      return access;
+    }
+
+    private void increment() {
+      consumeCount.set(consumeCount.incrementAndGet());
+      remaining.set(remaining.decrementAndGet());
+    }
   }
 }

--- a/src/test/java/io/vlingo/wire/fdx/bidirectional/netty/client/NettyClientRequestResponseChannelTest.java
+++ b/src/test/java/io/vlingo/wire/fdx/bidirectional/netty/client/NettyClientRequestResponseChannelTest.java
@@ -1,188 +1,189 @@
-// Copyright © 2012-2020 VLINGO LABS. All rights reserved.
+//// Copyright © 2012-2020 VLINGO LABS. All rights reserved.
+////
+//// This Source Code Form is subject to the terms of the
+//// Mozilla Public License, v. 2.0. If a copy of the MPL
+//// was not distributed with this file, You can obtain
+//// one at https://mozilla.org/MPL/2.0/.
+//package io.vlingo.wire.fdx.bidirectional.netty.client;
 //
-// This Source Code Form is subject to the terms of the
-// Mozilla Public License, v. 2.0. If a copy of the MPL
-// was not distributed with this file, You can obtain
-// one at https://mozilla.org/MPL/2.0/.
-package io.vlingo.wire.fdx.bidirectional.netty.client;
-
-import io.netty.bootstrap.ServerBootstrap;
-import io.netty.buffer.ByteBuf;
-import io.netty.channel.ChannelFuture;
-import io.netty.channel.ChannelHandlerContext;
-import io.netty.channel.ChannelInboundHandlerAdapter;
-import io.netty.channel.ChannelInitializer;
-import io.netty.channel.nio.NioEventLoopGroup;
-import io.netty.channel.socket.SocketChannel;
-import io.netty.channel.socket.nio.NioServerSocketChannel;
-import io.vlingo.actors.testkit.TestUntil;
-import io.vlingo.wire.channel.ResponseChannelConsumer;
-import io.vlingo.wire.fdx.bidirectional.TestResponseChannelConsumer;
-import io.vlingo.wire.node.Address;
-import io.vlingo.wire.node.AddressType;
-import io.vlingo.wire.node.Host;
-import org.junit.Assert;
-import org.junit.Test;
-
-import java.net.ConnectException;
-import java.nio.ByteBuffer;
-import java.nio.charset.Charset;
-import java.time.Duration;
-import java.util.Set;
-import java.util.UUID;
-import java.util.concurrent.CopyOnWriteArraySet;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicInteger;
-
-public class NettyClientRequestResponseChannelTest {
-  private static AtomicInteger TEST_PORT = new AtomicInteger(37370);
-
-  @Test
-  public void testServerNotAvailable() {
-    final ResponseChannelConsumer consumer = buffer -> {
-      Assert.fail("No replies are expected");
-    };
-
-    final Address address = Address.from(Host.of("localhost"), 8080, AddressType.MAIN);
-
-    final NettyClientRequestResponseChannel clientChannel = new NettyClientRequestResponseChannel(address, consumer, 1, 1, Duration.ofMillis(10),
-                                                                                                  Duration.ofMillis(1), Duration.ofMillis(1));
-
-    try {
-      clientChannel.requestWith(ByteBuffer.wrap(UUID.randomUUID()
-                                                    .toString()
-                                                    .getBytes()));
-    } catch (Exception e) {
-      Assert.assertTrue(e.getCause() instanceof ConnectException);
-    }
-  }
-
-  @Test
-  public void testServerRequestReply() throws InterruptedException {
-    final int nrExpectedMessages = 200;
-    final int requestMsgSize = 36;   //The length of UUID
-    final int replyMsSize = 36 + 6;  //The length of request + length of " reply"
-
-    final CountDownLatch connectionsCount = new CountDownLatch(1);
-    final CountDownLatch serverReceivedMessagesCount = new CountDownLatch(nrExpectedMessages);
-
-    final Set<String> serverReceivedMessage = new CopyOnWriteArraySet<>();
-    final Set<String> serverSentMessages = new CopyOnWriteArraySet<>();
-
-    final Set<String> clientSentMessages = new CopyOnWriteArraySet<>();
-
-    ChannelFuture server = null;
-    final NioEventLoopGroup parentGroup = new NioEventLoopGroup(2);
-    final NioEventLoopGroup childGroup = new NioEventLoopGroup(2);
-
-    try {
-      final int testPort = TEST_PORT.getAndIncrement();
-
-      server = bootstrapServer(requestMsgSize, connectionsCount, serverReceivedMessagesCount, serverReceivedMessage, serverSentMessages, parentGroup,
-                               childGroup, testPort);
-
-      final TestResponseChannelConsumer clientConsumer = new TestResponseChannelConsumer();
-      clientConsumer.currentExpectedResponseLength = replyMsSize;
-      clientConsumer.untilConsume = TestUntil.happenings(nrExpectedMessages);
-
-      final Address address = Address.from(Host.of("localhost"), testPort, AddressType.MAIN);
-
-      final NettyClientRequestResponseChannel clientChannel = new NettyClientRequestResponseChannel(address, clientConsumer, 10, replyMsSize);
-
-      for (int i = 0; i < nrExpectedMessages; i++) {
-        final String request = UUID.randomUUID()
-                                   .toString();
-        clientSentMessages.add(request);
-        clientChannel.requestWith(ByteBuffer.wrap(request.getBytes()));
-      }
-
-      Assert.assertTrue("Server should have received connection request", connectionsCount.await(2, TimeUnit.SECONDS));
-      Assert.assertTrue("Server should have received all messages.", serverReceivedMessagesCount.await(4, TimeUnit.SECONDS));
-
-      Assert.assertTrue("Client should have received all server replies", clientConsumer.untilConsume.completesWithin(TimeUnit.SECONDS.toMillis(4)));
-
-      clientSentMessages.forEach(clientRequest -> {
-        Assert.assertTrue("Server should have received request: " + clientRequest, serverReceivedMessage.contains(clientRequest));
-      });
-
-      serverSentMessages.forEach(serverReply -> {
-        Assert.assertTrue("Client should have received reply: " + serverReply, clientConsumer.responses.contains(serverReply));
-      });
-
-    } finally {
-      if (server != null) {
-        server.cancel(true);
-      }
-      parentGroup.shutdownGracefully()
-                 .await();
-      childGroup.shutdownGracefully()
-                .await();
-    }
-  }
-
-  private ChannelFuture bootstrapServer(final int requestMsgSize, final CountDownLatch connectionsCount, final CountDownLatch serverReceivedMessagesCount,
-                                        final Set<String> serverReceivedMessage, final Set<String> serverSentMessages, final NioEventLoopGroup parentGroup,
-                                        final NioEventLoopGroup childGroup, final int testPort) throws InterruptedException {
-    final ServerBootstrap b = new ServerBootstrap();
-
-    return b.group(parentGroup, childGroup)
-            .channel(NioServerSocketChannel.class)
-            .childHandler(new ChannelInitializer<SocketChannel>() {
-              @Override
-              public void initChannel(SocketChannel ch) throws Exception {
-                ch.pipeline()
-                  .addLast(new ChannelInboundHandlerAdapter() {
-                    private byte[] partialRequestBytes;
-
-                    @Override
-                    public void channelActive(final ChannelHandlerContext ctx) throws Exception {
-                      super.channelActive(ctx);
-                      connectionsCount.countDown();
-                    }
-
-                    @Override
-                    public void channelRead(final ChannelHandlerContext ctx, final Object msg) throws Exception {
-                      final ByteBuf byteBuf = (ByteBuf) msg;
-
-                      while (byteBuf.readableBytes() >= requestMsgSize) {
-                        final String request;
-                        if (partialRequestBytes != null && partialRequestBytes.length > 0) {
-                          final int remainingBytes = requestMsgSize - partialRequestBytes.length;
-                          request = new String(partialRequestBytes) + byteBuf.readCharSequence(remainingBytes, Charset.defaultCharset())
-                                                                             .toString();
-                          partialRequestBytes = null;
-                        } else {
-                          request = byteBuf.readCharSequence(requestMsgSize, Charset.defaultCharset())
-                                           .toString();
-                        }
-
-                        serverReceivedMessagesCount.countDown();
-                        serverReceivedMessage.add(request);
-
-                        final String reply = request + " reply";
-
-                        serverSentMessages.add(reply);
-
-                        final ByteBuf replyBuffer = ctx.alloc()
-                                                       .buffer(reply.getBytes().length);
-
-                        replyBuffer.writeBytes(reply.getBytes());
-
-                        ctx.writeAndFlush(replyBuffer);
-                      }
-
-                      if (byteBuf.readableBytes() > 0) {
-                        partialRequestBytes = new byte[byteBuf.readableBytes()];
-                        byteBuf.readBytes(partialRequestBytes);
-                      }
-                    }
-                  });
-              }
-            })
-            .bind(testPort)
-            .sync()
-            .await();
-  }
-
-}
+//import io.netty.bootstrap.ServerBootstrap;
+//import io.netty.buffer.ByteBuf;
+//import io.netty.channel.ChannelFuture;
+//import io.netty.channel.ChannelHandlerContext;
+//import io.netty.channel.ChannelInboundHandlerAdapter;
+//import io.netty.channel.ChannelInitializer;
+//import io.netty.channel.nio.NioEventLoopGroup;
+//import io.netty.channel.socket.SocketChannel;
+//import io.netty.channel.socket.nio.NioServerSocketChannel;
+//import io.vlingo.actors.testkit.TestUntil;
+//import io.vlingo.wire.channel.ResponseChannelConsumer;
+//import io.vlingo.wire.fdx.bidirectional.TestRequestChannelConsumer;
+//import io.vlingo.wire.fdx.bidirectional.TestResponseChannelConsumer;
+//import io.vlingo.wire.node.Address;
+//import io.vlingo.wire.node.AddressType;
+//import io.vlingo.wire.node.Host;
+//import org.junit.Assert;
+//import org.junit.Test;
+//
+//import java.net.ConnectException;
+//import java.nio.ByteBuffer;
+//import java.nio.charset.Charset;
+//import java.time.Duration;
+//import java.util.Set;
+//import java.util.UUID;
+//import java.util.concurrent.CopyOnWriteArraySet;
+//import java.util.concurrent.CountDownLatch;
+//import java.util.concurrent.TimeUnit;
+//import java.util.concurrent.atomic.AtomicInteger;
+//
+//public class NettyClientRequestResponseChannelTest {
+//  private static AtomicInteger TEST_PORT = new AtomicInteger(37370);
+//
+//  @Test
+//  public void testServerNotAvailable() {
+//    final ResponseChannelConsumer consumer = buffer -> {
+//      Assert.fail("No replies are expected");
+//    };
+//
+//    final Address address = Address.from(Host.of("localhost"), 8080, AddressType.MAIN);
+//
+//    final NettyClientRequestResponseChannel clientChannel = new NettyClientRequestResponseChannel(address, consumer, 1, 1, Duration.ofMillis(10),
+//                                                                                                  Duration.ofMillis(1), Duration.ofMillis(1));
+//
+//    try {
+//      clientChannel.requestWith(ByteBuffer.wrap(UUID.randomUUID()
+//                                                    .toString()
+//                                                    .getBytes()));
+//    } catch (Exception e) {
+//      Assert.assertTrue(e.getCause() instanceof ConnectException);
+//    }
+//  }
+//
+//  @Test
+//  public void testServerRequestReply() throws InterruptedException {
+//    final int nrExpectedMessages = 200;
+//    final int requestMsgSize = 36;   //The length of UUID
+//    final int replyMsSize = 36 + 6;  //The length of request + length of " reply"
+//
+//    final CountDownLatch connectionsCount = new CountDownLatch(1);
+//    final CountDownLatch serverReceivedMessagesCount = new CountDownLatch(nrExpectedMessages);
+//
+//    final Set<String> serverReceivedMessage = new CopyOnWriteArraySet<>();
+//    final Set<String> serverSentMessages = new CopyOnWriteArraySet<>();
+//
+//    final Set<String> clientSentMessages = new CopyOnWriteArraySet<>();
+//
+//    ChannelFuture server = null;
+//    final NioEventLoopGroup parentGroup = new NioEventLoopGroup(2);
+//    final NioEventLoopGroup childGroup = new NioEventLoopGroup(2);
+//
+//    try {
+//      final int testPort = TEST_PORT.getAndIncrement();
+//
+//      server = bootstrapServer(requestMsgSize, connectionsCount, serverReceivedMessagesCount, serverReceivedMessage, serverSentMessages, parentGroup,
+//                               childGroup, testPort);
+//
+//      final TestResponseChannelConsumer clientConsumer = new TestResponseChannelConsumer();
+//      clientConsumer.currentExpectedResponseLength = replyMsSize;
+//      clientConsumer.state = new TestResponseChannelConsumer.State(nrExpectedMessages);
+//
+//      final Address address = Address.from(Host.of("localhost"), testPort, AddressType.MAIN);
+//
+//      final NettyClientRequestResponseChannel clientChannel = new NettyClientRequestResponseChannel(address, clientConsumer, 10, replyMsSize);
+//
+//      for (int i = 0; i < nrExpectedMessages; i++) {
+//        final String request = UUID.randomUUID()
+//                                   .toString();
+//        clientSentMessages.add(request);
+//        clientChannel.requestWith(ByteBuffer.wrap(request.getBytes()));
+//      }
+//
+//      Assert.assertTrue("Server should have received connection request", connectionsCount.await(2, TimeUnit.SECONDS));
+//      Assert.assertTrue("Server should have received all messages.", serverReceivedMessagesCount.await(4, TimeUnit.SECONDS));
+//
+//      Assert.assertTrue("Client should have received all server replies", clientConsumer.untilConsume.completesWithin(TimeUnit.SECONDS.toMillis(4)));
+//
+//      clientSentMessages.forEach(clientRequest -> {
+//        Assert.assertTrue("Server should have received request: " + clientRequest, serverReceivedMessage.contains(clientRequest));
+//      });
+//
+//      serverSentMessages.forEach(serverReply -> {
+//        Assert.assertTrue("Client should have received reply: " + serverReply, clientConsumer.responses.contains(serverReply));
+//      });
+//
+//    } finally {
+//      if (server != null) {
+//        server.cancel(true);
+//      }
+//      parentGroup.shutdownGracefully()
+//                 .await();
+//      childGroup.shutdownGracefully()
+//                .await();
+//    }
+//  }
+//
+//  private ChannelFuture bootstrapServer(final int requestMsgSize, final CountDownLatch connectionsCount, final CountDownLatch serverReceivedMessagesCount,
+//                                        final Set<String> serverReceivedMessage, final Set<String> serverSentMessages, final NioEventLoopGroup parentGroup,
+//                                        final NioEventLoopGroup childGroup, final int testPort) throws InterruptedException {
+//    final ServerBootstrap b = new ServerBootstrap();
+//
+//    return b.group(parentGroup, childGroup)
+//            .channel(NioServerSocketChannel.class)
+//            .childHandler(new ChannelInitializer<SocketChannel>() {
+//              @Override
+//              public void initChannel(SocketChannel ch) throws Exception {
+//                ch.pipeline()
+//                  .addLast(new ChannelInboundHandlerAdapter() {
+//                    private byte[] partialRequestBytes;
+//
+//                    @Override
+//                    public void channelActive(final ChannelHandlerContext ctx) throws Exception {
+//                      super.channelActive(ctx);
+//                      connectionsCount.countDown();
+//                    }
+//
+//                    @Override
+//                    public void channelRead(final ChannelHandlerContext ctx, final Object msg) throws Exception {
+//                      final ByteBuf byteBuf = (ByteBuf) msg;
+//
+//                      while (byteBuf.readableBytes() >= requestMsgSize) {
+//                        final String request;
+//                        if (partialRequestBytes != null && partialRequestBytes.length > 0) {
+//                          final int remainingBytes = requestMsgSize - partialRequestBytes.length;
+//                          request = new String(partialRequestBytes) + byteBuf.readCharSequence(remainingBytes, Charset.defaultCharset())
+//                                                                             .toString();
+//                          partialRequestBytes = null;
+//                        } else {
+//                          request = byteBuf.readCharSequence(requestMsgSize, Charset.defaultCharset())
+//                                           .toString();
+//                        }
+//
+//                        serverReceivedMessagesCount.countDown();
+//                        serverReceivedMessage.add(request);
+//
+//                        final String reply = request + " reply";
+//
+//                        serverSentMessages.add(reply);
+//
+//                        final ByteBuf replyBuffer = ctx.alloc()
+//                                                       .buffer(reply.getBytes().length);
+//
+//                        replyBuffer.writeBytes(reply.getBytes());
+//
+//                        ctx.writeAndFlush(replyBuffer);
+//                      }
+//
+//                      if (byteBuf.readableBytes() > 0) {
+//                        partialRequestBytes = new byte[byteBuf.readableBytes()];
+//                        byteBuf.readBytes(partialRequestBytes);
+//                      }
+//                    }
+//                  });
+//              }
+//            })
+//            .bind(testPort)
+//            .sync()
+//            .await();
+//  }
+//
+//}

--- a/src/test/java/io/vlingo/wire/fdx/bidirectional/netty/client/NettyClientRequestResponseChannelTest.java
+++ b/src/test/java/io/vlingo/wire/fdx/bidirectional/netty/client/NettyClientRequestResponseChannelTest.java
@@ -1,189 +1,189 @@
-//// Copyright © 2012-2020 VLINGO LABS. All rights reserved.
-////
-//// This Source Code Form is subject to the terms of the
-//// Mozilla Public License, v. 2.0. If a copy of the MPL
-//// was not distributed with this file, You can obtain
-//// one at https://mozilla.org/MPL/2.0/.
-//package io.vlingo.wire.fdx.bidirectional.netty.client;
+// Copyright © 2012-2020 VLINGO LABS. All rights reserved.
 //
-//import io.netty.bootstrap.ServerBootstrap;
-//import io.netty.buffer.ByteBuf;
-//import io.netty.channel.ChannelFuture;
-//import io.netty.channel.ChannelHandlerContext;
-//import io.netty.channel.ChannelInboundHandlerAdapter;
-//import io.netty.channel.ChannelInitializer;
-//import io.netty.channel.nio.NioEventLoopGroup;
-//import io.netty.channel.socket.SocketChannel;
-//import io.netty.channel.socket.nio.NioServerSocketChannel;
-//import io.vlingo.actors.testkit.TestUntil;
-//import io.vlingo.wire.channel.ResponseChannelConsumer;
-//import io.vlingo.wire.fdx.bidirectional.TestRequestChannelConsumer;
-//import io.vlingo.wire.fdx.bidirectional.TestResponseChannelConsumer;
-//import io.vlingo.wire.node.Address;
-//import io.vlingo.wire.node.AddressType;
-//import io.vlingo.wire.node.Host;
-//import org.junit.Assert;
-//import org.junit.Test;
-//
-//import java.net.ConnectException;
-//import java.nio.ByteBuffer;
-//import java.nio.charset.Charset;
-//import java.time.Duration;
-//import java.util.Set;
-//import java.util.UUID;
-//import java.util.concurrent.CopyOnWriteArraySet;
-//import java.util.concurrent.CountDownLatch;
-//import java.util.concurrent.TimeUnit;
-//import java.util.concurrent.atomic.AtomicInteger;
-//
-//public class NettyClientRequestResponseChannelTest {
-//  private static AtomicInteger TEST_PORT = new AtomicInteger(37370);
-//
-//  @Test
-//  public void testServerNotAvailable() {
-//    final ResponseChannelConsumer consumer = buffer -> {
-//      Assert.fail("No replies are expected");
-//    };
-//
-//    final Address address = Address.from(Host.of("localhost"), 8080, AddressType.MAIN);
-//
-//    final NettyClientRequestResponseChannel clientChannel = new NettyClientRequestResponseChannel(address, consumer, 1, 1, Duration.ofMillis(10),
-//                                                                                                  Duration.ofMillis(1), Duration.ofMillis(1));
-//
-//    try {
-//      clientChannel.requestWith(ByteBuffer.wrap(UUID.randomUUID()
-//                                                    .toString()
-//                                                    .getBytes()));
-//    } catch (Exception e) {
-//      Assert.assertTrue(e.getCause() instanceof ConnectException);
-//    }
-//  }
-//
-//  @Test
-//  public void testServerRequestReply() throws InterruptedException {
-//    final int nrExpectedMessages = 200;
-//    final int requestMsgSize = 36;   //The length of UUID
-//    final int replyMsSize = 36 + 6;  //The length of request + length of " reply"
-//
-//    final CountDownLatch connectionsCount = new CountDownLatch(1);
-//    final CountDownLatch serverReceivedMessagesCount = new CountDownLatch(nrExpectedMessages);
-//
-//    final Set<String> serverReceivedMessage = new CopyOnWriteArraySet<>();
-//    final Set<String> serverSentMessages = new CopyOnWriteArraySet<>();
-//
-//    final Set<String> clientSentMessages = new CopyOnWriteArraySet<>();
-//
-//    ChannelFuture server = null;
-//    final NioEventLoopGroup parentGroup = new NioEventLoopGroup(2);
-//    final NioEventLoopGroup childGroup = new NioEventLoopGroup(2);
-//
-//    try {
-//      final int testPort = TEST_PORT.getAndIncrement();
-//
-//      server = bootstrapServer(requestMsgSize, connectionsCount, serverReceivedMessagesCount, serverReceivedMessage, serverSentMessages, parentGroup,
-//                               childGroup, testPort);
-//
-//      final TestResponseChannelConsumer clientConsumer = new TestResponseChannelConsumer();
-//      clientConsumer.currentExpectedResponseLength = replyMsSize;
-//      clientConsumer.state = new TestResponseChannelConsumer.State(nrExpectedMessages);
-//
-//      final Address address = Address.from(Host.of("localhost"), testPort, AddressType.MAIN);
-//
-//      final NettyClientRequestResponseChannel clientChannel = new NettyClientRequestResponseChannel(address, clientConsumer, 10, replyMsSize);
-//
-//      for (int i = 0; i < nrExpectedMessages; i++) {
-//        final String request = UUID.randomUUID()
-//                                   .toString();
-//        clientSentMessages.add(request);
-//        clientChannel.requestWith(ByteBuffer.wrap(request.getBytes()));
-//      }
-//
-//      Assert.assertTrue("Server should have received connection request", connectionsCount.await(2, TimeUnit.SECONDS));
-//      Assert.assertTrue("Server should have received all messages.", serverReceivedMessagesCount.await(4, TimeUnit.SECONDS));
-//
-//      Assert.assertTrue("Client should have received all server replies", clientConsumer.untilConsume.completesWithin(TimeUnit.SECONDS.toMillis(4)));
-//
-//      clientSentMessages.forEach(clientRequest -> {
-//        Assert.assertTrue("Server should have received request: " + clientRequest, serverReceivedMessage.contains(clientRequest));
-//      });
-//
-//      serverSentMessages.forEach(serverReply -> {
-//        Assert.assertTrue("Client should have received reply: " + serverReply, clientConsumer.responses.contains(serverReply));
-//      });
-//
-//    } finally {
-//      if (server != null) {
-//        server.cancel(true);
-//      }
-//      parentGroup.shutdownGracefully()
-//                 .await();
-//      childGroup.shutdownGracefully()
-//                .await();
-//    }
-//  }
-//
-//  private ChannelFuture bootstrapServer(final int requestMsgSize, final CountDownLatch connectionsCount, final CountDownLatch serverReceivedMessagesCount,
-//                                        final Set<String> serverReceivedMessage, final Set<String> serverSentMessages, final NioEventLoopGroup parentGroup,
-//                                        final NioEventLoopGroup childGroup, final int testPort) throws InterruptedException {
-//    final ServerBootstrap b = new ServerBootstrap();
-//
-//    return b.group(parentGroup, childGroup)
-//            .channel(NioServerSocketChannel.class)
-//            .childHandler(new ChannelInitializer<SocketChannel>() {
-//              @Override
-//              public void initChannel(SocketChannel ch) throws Exception {
-//                ch.pipeline()
-//                  .addLast(new ChannelInboundHandlerAdapter() {
-//                    private byte[] partialRequestBytes;
-//
-//                    @Override
-//                    public void channelActive(final ChannelHandlerContext ctx) throws Exception {
-//                      super.channelActive(ctx);
-//                      connectionsCount.countDown();
-//                    }
-//
-//                    @Override
-//                    public void channelRead(final ChannelHandlerContext ctx, final Object msg) throws Exception {
-//                      final ByteBuf byteBuf = (ByteBuf) msg;
-//
-//                      while (byteBuf.readableBytes() >= requestMsgSize) {
-//                        final String request;
-//                        if (partialRequestBytes != null && partialRequestBytes.length > 0) {
-//                          final int remainingBytes = requestMsgSize - partialRequestBytes.length;
-//                          request = new String(partialRequestBytes) + byteBuf.readCharSequence(remainingBytes, Charset.defaultCharset())
-//                                                                             .toString();
-//                          partialRequestBytes = null;
-//                        } else {
-//                          request = byteBuf.readCharSequence(requestMsgSize, Charset.defaultCharset())
-//                                           .toString();
-//                        }
-//
-//                        serverReceivedMessagesCount.countDown();
-//                        serverReceivedMessage.add(request);
-//
-//                        final String reply = request + " reply";
-//
-//                        serverSentMessages.add(reply);
-//
-//                        final ByteBuf replyBuffer = ctx.alloc()
-//                                                       .buffer(reply.getBytes().length);
-//
-//                        replyBuffer.writeBytes(reply.getBytes());
-//
-//                        ctx.writeAndFlush(replyBuffer);
-//                      }
-//
-//                      if (byteBuf.readableBytes() > 0) {
-//                        partialRequestBytes = new byte[byteBuf.readableBytes()];
-//                        byteBuf.readBytes(partialRequestBytes);
-//                      }
-//                    }
-//                  });
-//              }
-//            })
-//            .bind(testPort)
-//            .sync()
-//            .await();
-//  }
-//
-//}
+// This Source Code Form is subject to the terms of the
+// Mozilla Public License, v. 2.0. If a copy of the MPL
+// was not distributed with this file, You can obtain
+// one at https://mozilla.org/MPL/2.0/.
+package io.vlingo.wire.fdx.bidirectional.netty.client;
+
+import io.netty.bootstrap.ServerBootstrap;
+import io.netty.buffer.ByteBuf;
+import io.netty.channel.ChannelFuture;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandlerAdapter;
+import io.netty.channel.ChannelInitializer;
+import io.netty.channel.nio.NioEventLoopGroup;
+import io.netty.channel.socket.SocketChannel;
+import io.netty.channel.socket.nio.NioServerSocketChannel;
+import io.vlingo.actors.testkit.TestUntil;
+import io.vlingo.wire.channel.ResponseChannelConsumer;
+import io.vlingo.wire.fdx.bidirectional.TestRequestChannelConsumer;
+import io.vlingo.wire.fdx.bidirectional.TestResponseChannelConsumer;
+import io.vlingo.wire.node.Address;
+import io.vlingo.wire.node.AddressType;
+import io.vlingo.wire.node.Host;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.net.ConnectException;
+import java.nio.ByteBuffer;
+import java.nio.charset.Charset;
+import java.time.Duration;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.CopyOnWriteArraySet;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class NettyClientRequestResponseChannelTest {
+  private static AtomicInteger TEST_PORT = new AtomicInteger(37370);
+
+  @Test
+  public void testServerNotAvailable() {
+    final ResponseChannelConsumer consumer = buffer -> {
+      Assert.fail("No replies are expected");
+    };
+
+    final Address address = Address.from(Host.of("localhost"), 8080, AddressType.MAIN);
+
+    final NettyClientRequestResponseChannel clientChannel = new NettyClientRequestResponseChannel(address, consumer, 1, 1, Duration.ofMillis(10),
+                                                                                                  Duration.ofMillis(1), Duration.ofMillis(1));
+
+    try {
+      clientChannel.requestWith(ByteBuffer.wrap(UUID.randomUUID()
+                                                    .toString()
+                                                    .getBytes()));
+    } catch (Exception e) {
+      Assert.assertTrue(e.getCause() instanceof ConnectException);
+    }
+  }
+
+  @Test
+  public void testServerRequestReply() throws InterruptedException {
+    final int nrExpectedMessages = 200;
+    final int requestMsgSize = 36;   //The length of UUID
+    final int replyMsSize = 36 + 6;  //The length of request + length of " reply"
+
+    final CountDownLatch connectionsCount = new CountDownLatch(1);
+    final CountDownLatch serverReceivedMessagesCount = new CountDownLatch(nrExpectedMessages);
+
+    final Set<String> serverReceivedMessage = new CopyOnWriteArraySet<>();
+    final Set<String> serverSentMessages = new CopyOnWriteArraySet<>();
+
+    final Set<String> clientSentMessages = new CopyOnWriteArraySet<>();
+
+    ChannelFuture server = null;
+    final NioEventLoopGroup parentGroup = new NioEventLoopGroup(2);
+    final NioEventLoopGroup childGroup = new NioEventLoopGroup(2);
+
+    try {
+      final int testPort = TEST_PORT.getAndIncrement();
+
+      server = bootstrapServer(requestMsgSize, connectionsCount, serverReceivedMessagesCount, serverReceivedMessage, serverSentMessages, parentGroup,
+                               childGroup, testPort);
+
+      final TestResponseChannelConsumer clientConsumer = new TestResponseChannelConsumer();
+      clientConsumer.currentExpectedResponseLength = replyMsSize;
+      clientConsumer.state = new TestResponseChannelConsumer.State(nrExpectedMessages);
+
+      final Address address = Address.from(Host.of("localhost"), testPort, AddressType.MAIN);
+
+      final NettyClientRequestResponseChannel clientChannel = new NettyClientRequestResponseChannel(address, clientConsumer, 10, replyMsSize);
+
+      for (int i = 0; i < nrExpectedMessages; i++) {
+        final String request = UUID.randomUUID()
+                                   .toString();
+        clientSentMessages.add(request);
+        clientChannel.requestWith(ByteBuffer.wrap(request.getBytes()));
+      }
+
+      Assert.assertTrue("Server should have received connection request", connectionsCount.await(2, TimeUnit.SECONDS));
+      Assert.assertTrue("Server should have received all messages.", serverReceivedMessagesCount.await(4, TimeUnit.SECONDS));
+
+      Assert.assertEquals("Client should have received all server replies", 0, (int) clientConsumer.state.access.readFrom("remaining"));
+
+      clientSentMessages.forEach(clientRequest -> {
+        Assert.assertTrue("Server should have received request: " + clientRequest, serverReceivedMessage.contains(clientRequest));
+      });
+
+      serverSentMessages.forEach(serverReply -> {
+        Assert.assertTrue("Client should have received reply: " + serverReply, clientConsumer.responses.contains(serverReply));
+      });
+
+    } finally {
+      if (server != null) {
+        server.cancel(true);
+      }
+      parentGroup.shutdownGracefully()
+                 .await();
+      childGroup.shutdownGracefully()
+                .await();
+    }
+  }
+
+  private ChannelFuture bootstrapServer(final int requestMsgSize, final CountDownLatch connectionsCount, final CountDownLatch serverReceivedMessagesCount,
+                                        final Set<String> serverReceivedMessage, final Set<String> serverSentMessages, final NioEventLoopGroup parentGroup,
+                                        final NioEventLoopGroup childGroup, final int testPort) throws InterruptedException {
+    final ServerBootstrap b = new ServerBootstrap();
+
+    return b.group(parentGroup, childGroup)
+            .channel(NioServerSocketChannel.class)
+            .childHandler(new ChannelInitializer<SocketChannel>() {
+              @Override
+              public void initChannel(SocketChannel ch) throws Exception {
+                ch.pipeline()
+                  .addLast(new ChannelInboundHandlerAdapter() {
+                    private byte[] partialRequestBytes;
+
+                    @Override
+                    public void channelActive(final ChannelHandlerContext ctx) throws Exception {
+                      super.channelActive(ctx);
+                      connectionsCount.countDown();
+                    }
+
+                    @Override
+                    public void channelRead(final ChannelHandlerContext ctx, final Object msg) throws Exception {
+                      final ByteBuf byteBuf = (ByteBuf) msg;
+
+                      while (byteBuf.readableBytes() >= requestMsgSize) {
+                        final String request;
+                        if (partialRequestBytes != null && partialRequestBytes.length > 0) {
+                          final int remainingBytes = requestMsgSize - partialRequestBytes.length;
+                          request = new String(partialRequestBytes) + byteBuf.readCharSequence(remainingBytes, Charset.defaultCharset())
+                                                                             .toString();
+                          partialRequestBytes = null;
+                        } else {
+                          request = byteBuf.readCharSequence(requestMsgSize, Charset.defaultCharset())
+                                           .toString();
+                        }
+
+                        serverReceivedMessagesCount.countDown();
+                        serverReceivedMessage.add(request);
+
+                        final String reply = request + " reply";
+
+                        serverSentMessages.add(reply);
+
+                        final ByteBuf replyBuffer = ctx.alloc()
+                                                       .buffer(reply.getBytes().length);
+
+                        replyBuffer.writeBytes(reply.getBytes());
+
+                        ctx.writeAndFlush(replyBuffer);
+                      }
+
+                      if (byteBuf.readableBytes() > 0) {
+                        partialRequestBytes = new byte[byteBuf.readableBytes()];
+                        byteBuf.readBytes(partialRequestBytes);
+                      }
+                    }
+                  });
+              }
+            })
+            .bind(testPort)
+            .sync()
+            .await();
+  }
+
+}

--- a/src/test/java/io/vlingo/wire/fdx/bidirectional/netty/client/NettyClientRequestResponseChannelTest.java
+++ b/src/test/java/io/vlingo/wire/fdx/bidirectional/netty/client/NettyClientRequestResponseChannelTest.java
@@ -4,6 +4,7 @@
 // Mozilla Public License, v. 2.0. If a copy of the MPL
 // was not distributed with this file, You can obtain
 // one at https://mozilla.org/MPL/2.0/.
+
 package io.vlingo.wire.fdx.bidirectional.netty.client;
 
 import io.netty.bootstrap.ServerBootstrap;
@@ -15,9 +16,7 @@ import io.netty.channel.ChannelInitializer;
 import io.netty.channel.nio.NioEventLoopGroup;
 import io.netty.channel.socket.SocketChannel;
 import io.netty.channel.socket.nio.NioServerSocketChannel;
-import io.vlingo.actors.testkit.TestUntil;
 import io.vlingo.wire.channel.ResponseChannelConsumer;
-import io.vlingo.wire.fdx.bidirectional.TestRequestChannelConsumer;
 import io.vlingo.wire.fdx.bidirectional.TestResponseChannelConsumer;
 import io.vlingo.wire.node.Address;
 import io.vlingo.wire.node.AddressType;

--- a/src/test/java/io/vlingo/wire/fdx/inbound/InboundStreamTest.java
+++ b/src/test/java/io/vlingo/wire/fdx/inbound/InboundStreamTest.java
@@ -10,6 +10,7 @@ package io.vlingo.wire.fdx.inbound;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
+import io.vlingo.wire.fdx.inbound.MockInboundStreamInterest.TestResults;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -30,8 +31,9 @@ public class InboundStreamTest extends AbstractMessageTool {
 
   @Test
   public void testInbound() throws Exception {
-    interest.testResults.untilStops = TestUntil.happenings(1);
-    while (reader.probeChannelCount.get() == 0)
+    interest.testResults = new TestResults(1);
+    reader.results = new MockChannelReader.Results(1);
+    while ((int) reader.results.access.readFrom("probeChannelCount") == 0)
       ;
     inboundStream.actor().stop();
     int count;
@@ -40,8 +42,8 @@ public class InboundStreamTest extends AbstractMessageTool {
       assertEquals(MockChannelReader.MessagePrefix + (count + 1), message);
     }
 
-    assertTrue(interest.testResults.messageCount.get() > 0);
-    assertEquals(count, reader.probeChannelCount.get());
+    assertTrue((int) interest.testResults.access.readFrom("messageCount") > 0);
+    assertEquals(count, (int) reader.results.access.readFrom("probeChannelCount"));
   }
 
   @Before

--- a/src/test/java/io/vlingo/wire/fdx/inbound/InboundStreamTest.java
+++ b/src/test/java/io/vlingo/wire/fdx/inbound/InboundStreamTest.java
@@ -16,7 +16,6 @@ import org.junit.Test;
 
 import io.vlingo.actors.Definition;
 import io.vlingo.actors.testkit.TestActor;
-import io.vlingo.actors.testkit.TestUntil;
 import io.vlingo.actors.testkit.TestWorld;
 import io.vlingo.wire.channel.MockChannelReader;
 import io.vlingo.wire.fdx.inbound.InboundStream.InboundStreamInstantiator;
@@ -35,12 +34,11 @@ public class InboundStreamTest extends AbstractMessageTool {
     while (reader.probeChannelCount.get() == 0)
       ;
     inboundStream.actor().stop();
-    int count = 0;
-    for (final String message : interest.testResults.messages) {
-      ++count;
-      assertEquals(MockChannelReader.MessagePrefix + count, message);
+    int count;
+    for (count = 0; count < (int) interest.testResults.access.readFrom("messageCount"); count++) {
+      String message = interest.testResults.access.readFrom("messages", count);
+      assertEquals(MockChannelReader.MessagePrefix + (count + 1), message);
     }
-    interest.testResults.untilStops.completes();
 
     assertTrue(interest.testResults.messageCount.get() > 0);
     assertEquals(count, reader.probeChannelCount.get());

--- a/src/test/java/io/vlingo/wire/fdx/inbound/MockInboundStreamInterest.java
+++ b/src/test/java/io/vlingo/wire/fdx/inbound/MockInboundStreamInterest.java
@@ -10,6 +10,7 @@ package io.vlingo.wire.fdx.inbound;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Consumer;
 
 import io.vlingo.actors.testkit.TestUntil;
 import io.vlingo.wire.message.AbstractMessageTool;
@@ -17,17 +18,19 @@ import io.vlingo.wire.message.RawMessage;
 import io.vlingo.wire.node.AddressType;
 
 public class MockInboundStreamInterest extends AbstractMessageTool implements InboundStreamInterest {
-  public TestResults testResults = new TestResults();
+  public TestResults testResults;
 
   public MockInboundStreamInterest() { }
   
   @Override
   public void handleInboundStreamMessage(final AddressType addressType, final RawMessage message) {
     final String textMessage = message.asTextMessage();
-    testResults.messages.add(textMessage);
-    testResults.messageCount.incrementAndGet();
-    System.out.println("INTEREST: " + textMessage + " list-size: " + testResults.messages.size() + " count: " + testResults.messageCount.get() + " count-down: " + testResults.untilStops.remaining());
-    testResults.untilStops.happened();
+    testResults.access.writeUsing("messages", textMessage);
+    testResults.access.writeUsing("messageCount", 1);
+    System.out.println("INTEREST: " + textMessage +
+            " list-size: " + testResults.access.readFrom("messagesSize") +
+            " count: " + testResults.access.readFrom("messageCount") +
+            " count-down: " + testResults.access.readFrom("remaining"));
   }
 
   static class TestResults {


### PR DESCRIPTION
Implements #3.
I see that RSocket test is failing on master: RSocketClientChannelTest.testServerApplicationErrorsProcess:194 Server should have received all messages.
Shouldn't it be `@Ignore`d for now?