### PR TITLE
Reuse the same NettyInboundHandler for incoming requests

### DIFF
--- a/src/main/java/io/vlingo/wire/fdx/bidirectional/netty/server/NettyInboundHandler.java
+++ b/src/main/java/io/vlingo/wire/fdx/bidirectional/netty/server/NettyInboundHandler.java
@@ -6,19 +6,10 @@
 // one at https://mozilla.org/MPL/2.0/.
 package io.vlingo.wire.fdx.bidirectional.netty.server;
 
-import java.util.concurrent.atomic.AtomicLong;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.EmptyByteBuf;
 import io.netty.buffer.Unpooled;
-import io.netty.channel.Channel;
-import io.netty.channel.ChannelFuture;
-import io.netty.channel.ChannelFutureListener;
-import io.netty.channel.ChannelHandlerContext;
-import io.netty.channel.ChannelInboundHandlerAdapter;
+import io.netty.channel.*;
 import io.netty.util.AttributeKey;
 import io.netty.util.ReferenceCountUtil;
 import io.vlingo.common.pool.ElasticResourcePool;
@@ -29,7 +20,12 @@ import io.vlingo.wire.channel.ResponseSenderChannel;
 import io.vlingo.wire.message.BasicConsumerByteBuffer;
 import io.vlingo.wire.message.ConsumerByteBuffer;
 import io.vlingo.wire.message.ConsumerByteBufferPool;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
+import java.util.concurrent.atomic.AtomicLong;
+
+@ChannelHandler.Sharable
 final class NettyInboundHandler extends ChannelInboundHandlerAdapter implements ResponseSenderChannel {
   private final static Logger logger = LoggerFactory.getLogger(NettyInboundHandler.class);
 

--- a/src/main/java/io/vlingo/wire/fdx/bidirectional/netty/server/NettyServerChannelActor.java
+++ b/src/main/java/io/vlingo/wire/fdx/bidirectional/netty/server/NettyServerChannelActor.java
@@ -6,12 +6,6 @@
 // one at https://mozilla.org/MPL/2.0/.
 package io.vlingo.wire.fdx.bidirectional.netty.server;
 
-import java.time.Duration;
-import java.util.concurrent.TimeUnit;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import io.netty.bootstrap.ServerBootstrap;
 import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelInitializer;
@@ -29,6 +23,11 @@ import io.vlingo.common.Completes;
 import io.vlingo.wire.channel.RequestChannelConsumerProvider;
 import io.vlingo.wire.fdx.bidirectional.ServerRequestResponseChannel;
 import io.vlingo.wire.message.ConsumerByteBufferPool;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
 
 /**
  * Implementation of {@link ServerRequestResponseChannel} based on Netty (https://netty.io/wiki/user-guide-for-4.x.html)
@@ -72,6 +71,7 @@ public class NettyServerChannelActor extends Actor implements ServerRequestRespo
 
     try {
       final ServerBootstrap b = new ServerBootstrap();
+      final NettyInboundHandler inboundHandler = new NettyInboundHandler(provider, maxBufferPoolSize, maxMessageSize);
 
       this.channelFuture = b.group(bossGroup, workerGroup)
                             .channel(serverSocketChannelType())
@@ -80,7 +80,7 @@ public class NettyServerChannelActor extends Actor implements ServerRequestRespo
                               public void initChannel(final SocketChannel channel) throws Exception {
                                 channel
                                   .pipeline()
-                                  .addLast(new NettyInboundHandler(provider, maxBufferPoolSize, maxMessageSize));
+                                  .addLast(inboundHandler);
                               }
                             })
                             .bind(port)


### PR DESCRIPTION
Previously for each request a new NettyInboundHandler object was created.
These objects accumulate quite fast provoking OutOfMemoryError.

Before:
![vlingo-helloworld_before-issue-47](https://user-images.githubusercontent.com/8297532/100528491-1c2ecb80-31e6-11eb-8f66-c4025ce9ac65.png)

After:
![vlingo-helloworld_after-issue-47](https://user-images.githubusercontent.com/8297532/100528496-497b7980-31e6-11eb-9395-6712ef99c036.png)
